### PR TITLE
Improved error handling in VersionCheck.m

### DIFF
--- a/VersionCheck.m
+++ b/VersionCheck.m
@@ -14,9 +14,11 @@ persistent lastCheckTime
 
 if nargin < 2
     loadFile = which('GannetLoad');
+    if isempty(loadFile)
+        error('Cannot find GannetLoad; please ensure that your Gannet folder is included in the MATLAB search path.')
+    end
     fileID = fopen(loadFile, 'rt');
     if fileID == -1
-        fclose(fileID);
         error('Cannot read %s.', loadFile);
     end
     str = fread(fileID, Inf, '*uchar');
@@ -32,25 +34,33 @@ end
 
 newVersionAvailable = 0;
 if nargin < 2 || isempty(lastCheckTime) || (datetime('now') - lastCheckTime) > days(1)
+
     url = 'https://raw.githubusercontent.com/markmikkelsen/Gannet/main/GannetLoad.m';
     str = readURL(url);
-    expression = '(?<field>MRS_struct.version.Gannet = )''(?<version>.*?)''';
-    out = regexp(str, expression, 'names');
-    latestVersion = out.version;
-    if str2double(latestVersion(regexpi(latestVersion,'\d'))) > str2double(currentVersion(regexpi(currentVersion,'\d')))
-        newVersionAvailable = 1;
-        msg = ['\n', ...
-               '***********************************************************************************************\n', ...
-               'A newer version of Gannet (%s) is available. You are currently using version %s.\n' ...
-               'You can download the newer version from GitHub or run UpdateGannet to install it directly.\n', ...
-               '***********************************************************************************************\n\n'];
-        msg = hyperlink('https://github.com/markmikkelsen/Gannet', 'GitHub', msg);
-        msg = hyperlink('matlab:UpdateGannet', 'UpdateGannet', msg);
+    if isempty(str)
         if ~silent
-            fprintf(msg, latestVersion, currentVersion);
+            warning('Unable to check for Gannet updates; this may happen if your system has limited internet access');
         end
+        newVersionAvailable = 0;
+    else
+        expression = '(?<field>MRS_struct.version.Gannet = )''(?<version>.*?)''';
+        out = regexp(str, expression, 'names');
+        latestVersion = out.version;
+        if str2double(latestVersion(regexpi(latestVersion,'\d'))) > str2double(currentVersion(regexpi(currentVersion,'\d')))
+            newVersionAvailable = 1;
+            msg = ['\n', ...
+                   '***********************************************************************************************\n', ...
+                   'A newer version of Gannet (%s) is available. You are currently using version %s.\n' ...
+                   'You can download the newer version from GitHub or run UpdateGannet to install it directly.\n', ...
+                   '***********************************************************************************************\n\n'];
+            msg = hyperlink('https://github.com/markmikkelsen/Gannet', 'GitHub', msg);
+            msg = hyperlink('matlab:UpdateGannet', 'UpdateGannet', msg);
+            if ~silent
+                fprintf(msg, latestVersion, currentVersion);
+            end
+        end
+        lastCheckTime = datetime('now');
     end
-    lastCheckTime = datetime('now');
 end
 
 if nargout == 1
@@ -61,22 +71,26 @@ elseif nargout == 2
 end
 
     function str = readURL(url)
+        % ARC 2023-06-27, exception handling also for urlread calls
         try
-            str = char(webread(url));
-        catch err
-            if isempty(strfind(err.message,'404'))
-                v = version;
-                if v(1) >= '8' % 8.0 (R2012b)
-                    str = urlread(url, 'Timeout', 5); %#ok<URLRD>
-                else
-                    str = urlread(url); %#ok<URLRD> % R2012a or older (no timeout parameter)
-                end
+            if verLessThan('matlab','8.0')
+                str = urlread(url); %#ok<URLRD> % R2012a or older (no timeout parameter)
+            elseif verLessThan('matlab','8.4')
+                str = urlread(url, 'Timeout', 5); %#ok<URLRD> % pre R2014b, no webread function
             else
-                rethrow(err);
+                wo = weboptions('Timeout',5); % (note, 5 sec is consistent with Matlab default)
+                str = char(webread(url, wo));
             end
-        end
-        if size(str,1) > 1  % ensure a row-wise string
-            str = str';
+            if size(str,1) > 1  % ensure a row-wise string
+                str = str';
+            end
+        catch err
+            if ~isempty(strfind(err.message,'404'))
+                rethrow(err);
+            else
+              warning(err.message);
+              str = '';
+            end
         end
     end
 


### PR DESCRIPTION
See https://forum.mrshub.org/t/gannet-was-unable-to-process-the-data-acquired-by-the-ge-scanner-due-to-a-code-error/1405/9 and https://forum.mrshub.org/t/new-data-processing-error/1425

VersionCheck was failing on systems with limited internet access, eg where DNS is available (so the first check passes) but https traffic is restricted (so webread/urlread fails).

This update wraps all the read calls in an exception handler, and avoids redundant urlread requests in the scenario that the initial webread fails. Also ensures sensible fall-through behaviour if those calls do fail.

Additional minor cleanup for version checking (previous version is likely to fail with major version > 9) and local GannetLoad checks.