### PR TITLE
Set figure theme to light for MATLAB R2025a and newer

### DIFF
--- a/CoRegStandAlone/CoReg.m
+++ b/CoRegStandAlone/CoReg.m
@@ -112,6 +112,9 @@ for ii = 1:numscans
         else
             h = figure(103);
         end
+        if ~isMATLABReleaseOlderThan("R2025a")
+            h.Theme = 'light';
+        end
         scr_sz = get(0,'ScreenSize');
         fig_w = 1000;
         fig_h = 707;

--- a/CoRegStandAlone/Seg.m
+++ b/CoRegStandAlone/Seg.m
@@ -185,6 +185,9 @@ for ii = 1:length(MRS_struct.metabfile)
         else
             h = figure(104);
         end
+        if ~isMATLABReleaseOlderThan("R2025a")
+            h.Theme = 'light';
+        end
         % Open figure in center of screen
         scr_sz = get(0,'ScreenSize');
         fig_w = 1000;

--- a/GannetCoRegister.m
+++ b/GannetCoRegister.m
@@ -23,7 +23,7 @@ if nargin == 2
 end
 
 MRS_struct.info.datetime.coreg = datetime('now');
-MRS_struct.info.version.coreg = '250911';
+MRS_struct.info.version.coreg = '250912';
 
 warning('off'); % temporarily suppress warning messages
 
@@ -165,6 +165,9 @@ for ii = 1:MRS_struct.p.numScans
             h = figure('Visible', 'off');
         else
             h = figure(103);
+        end
+        if ~isMATLABReleaseOlderThan("R2025a")
+            h.Theme = 'light';
         end
         % Open figure in center of screen
         scr_sz = get(0,'ScreenSize');

--- a/GannetFit.m
+++ b/GannetFit.m
@@ -12,7 +12,7 @@ if ~isstruct(MRS_struct)
 end
 
 MRS_struct.info.datetime.fit = datetime('now');
-MRS_struct.info.version.fit = '250911';
+MRS_struct.info.version.fit = '250912';
 
 if MRS_struct.p.PRIAM
     vox = MRS_struct.p.vox;
@@ -586,6 +586,9 @@ for kk = 1:length(vox)
                     h = figure('Visible', 'off');
                 else
                     h = figure(102);
+                end
+                if ~isMATLABReleaseOlderThan("R2025a")
+                    h.Theme = 'light';
                 end
                 % Open figure in center of screen
                 scr_sz = get(0,'ScreenSize');
@@ -1562,7 +1565,7 @@ end
 
 
 %%%%%%%%%%%%%%%% INSET FIGURE %%%%%%%%%%%%%%%%
-function [h_main, h_inset] = inset(main_handle, inset_handle,inset_size)
+function [h_main, h_inset] = inset(main_handle, inset_handle, inset_size)
 % Function for figure settings
 
 % The function plotting figure inside figure (main and inset) from 2 existing figures.

--- a/GannetFitPhantom.m
+++ b/GannetFitPhantom.m
@@ -301,6 +301,9 @@ for kk = 1:length(vox)
             else
                 h = figure(102);
             end
+            if ~isMATLABReleaseOlderThan("R2025a")
+                h.Theme = 'light';
+            end
             % Open figure in center of screen
             scr_sz = get(0,'ScreenSize');
             fig_w = 1000;

--- a/GannetLoad.m
+++ b/GannetLoad.m
@@ -21,7 +21,7 @@ end
 
 MRS_struct.info.datetime.load = datetime('now');
 MRS_struct.info.version.Gannet = '3.5.0';
-MRS_struct.info.version.load = '250910';
+MRS_struct.info.version.load = '250912';
 MRS_struct.p.bids = 0;
 VersionCheck(0, MRS_struct.info.version.Gannet);
 ToolboxCheck;
@@ -590,6 +590,9 @@ for ii = 1:MRS_struct.p.numScans % Loop over all files in the batch (from metabf
                 h = figure('Visible', 'off');
             else
                 h = figure(101);
+            end
+            if ~isMATLABReleaseOlderThan("R2025a")
+                h.Theme = 'light';
             end
             % Open figure in center of screen
             scr_sz = get(0,'ScreenSize');

--- a/GannetQuantify.m
+++ b/GannetQuantify.m
@@ -12,7 +12,7 @@ if ~isstruct(MRS_struct)
 end
 
 MRS_struct.info.datetime.quantify = datetime('now');
-MRS_struct.info.version.quantify = '250911';
+MRS_struct.info.version.quantify = '250912';
 
 if MRS_struct.p.PRIAM
     vox = MRS_struct.p.vox;
@@ -246,6 +246,9 @@ for kk = 1:length(vox)
             h = figure('Visible', 'off');
         else
             h = figure(105);
+        end
+        if ~isMATLABReleaseOlderThan("R2025a")
+            h.Theme = 'light';
         end
         % Open figure in center of screen
         scr_sz = get(0,'ScreenSize');

--- a/GannetSegment.m
+++ b/GannetSegment.m
@@ -17,7 +17,7 @@ if ~isstruct(MRS_struct)
 end
 
 MRS_struct.info.datetime.segment = datetime('now');
-MRS_struct.info.version.segment = '250911';
+MRS_struct.info.version.segment = '250912';
 
 warning('off'); % temporarily suppress warning messages
 
@@ -330,6 +330,9 @@ for kk = 1:length(vox)
             h = figure('Visible', 'off');
         else
             h = figure(104);
+        end
+        if ~isMATLABReleaseOlderThan("R2025a")
+            h.Theme = 'light';
         end
         % Open figure in center of screen
         scr_sz = get(0,'ScreenSize');


### PR DESCRIPTION
Added logic to set the figure theme to 'light' if running on MATLAB R2025a or newer in all relevant scripts. Also updated version numbers in Gannet modules to reflect these changes.