### PR TITLE
Merge with dev

### DIFF
--- a/GannetCoRegister.m
+++ b/GannetCoRegister.m
@@ -23,7 +23,13 @@ if nargin == 2
 end
 
 MRS_struct.info.datetime.coreg = datetime('now');
-MRS_struct.info.version.coreg = '250912';
+MRS_struct.info.version.coreg = '250914';
+
+if ~isMATLABReleaseOlderThan("R2025a") && MRS_struct.p.append
+    font_size_adj = 2.75;
+else
+    font_size_adj = 0;
+end
 
 warning('off'); % temporarily suppress warning messages
 
@@ -188,34 +194,34 @@ for ii = 1:MRS_struct.p.numScans
         if length(fname) > 30
             fname = [fname(1:12) '...' fname(end-11:end)];
         end
-        text(0.5, 0.75, 'Mask output: ', 'Units', 'normalized', 'HorizontalAlignment' , 'right', 'FontName', 'Arial', 'FontSize', 13);
-        text(0.5, 0.75, [' ' fname], 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13, 'Interpreter', 'none');
+        text(0.5, 0.75, 'Mask output: ', 'Units', 'normalized', 'HorizontalAlignment' , 'right', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj);
+        text(0.5, 0.75, [' ' fname], 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj, 'Interpreter', 'none');
 
-        text(0.5, 0.63, 'Spatial parameters: ', 'Units', 'normalized', 'HorizontalAlignment', 'right', 'FontName', 'Arial', 'FontSize', 13);
-        text(0.5, 0.63, ' [LR, PA, SI]', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13);
+        text(0.5, 0.63, 'Spatial parameters: ', 'Units', 'normalized', 'HorizontalAlignment', 'right', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj);
+        text(0.5, 0.63, ' [LR, PA, SI]', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj);
 
         str = [' ' num2str(MRS_struct.p.voxdim(ii,1)) ' \times ' num2str(MRS_struct.p.voxdim(ii,2)) ' \times ' num2str(MRS_struct.p.voxdim(ii,3)) ' mm^{3}'];
-        text(0.5, 0.51, 'Dimensions: ', 'Units', 'normalized', 'HorizontalAlignment', 'right', 'FontName', 'Arial', 'FontSize', 13);
-        text(0.5, 0.51, str, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13, 'Interpreter', 'tex');
+        text(0.5, 0.51, 'Dimensions: ', 'Units', 'normalized', 'HorizontalAlignment', 'right', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj);
+        text(0.5, 0.51, str, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj, 'Interpreter', 'tex');
 
         str = [' ' num2str(prod(MRS_struct.p.voxdim(ii,:))/1e3) ' mL'];
-        text(0.5, 0.39, 'Volume: ', 'Units', 'normalized', 'HorizontalAlignment', 'right', 'FontName', 'Arial', 'FontSize', 13);
-        text(0.5, 0.39, str, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13);
+        text(0.5, 0.39, 'Volume: ', 'Units', 'normalized', 'HorizontalAlignment', 'right', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj);
+        text(0.5, 0.39, str, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj);
 
         str = [' [' num2str(MRS_struct.p.voxoff(ii,1), '%3.1f') ', ' num2str(MRS_struct.p.voxoff(ii,2), '%3.1f') ', ' num2str(MRS_struct.p.voxoff(ii,3), '%3.1f') '] mm'];
-        text(0.5, 0.27, 'Position: ', 'Units', 'normalized', 'HorizontalAlignment', 'right', 'FontName', 'Arial', 'FontSize', 13);
-        text(0.5, 0.27, str, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13);
+        text(0.5, 0.27, 'Position: ', 'Units', 'normalized', 'HorizontalAlignment', 'right', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj);
+        text(0.5, 0.27, str, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj);
 
         if any(strcmp(MRS_struct.p.vendor, {'Philips', 'Philips_data'}))
             str = [' [' num2str(MRS_struct.p.voxang(ii,2), '%3.1f') ', ' num2str(MRS_struct.p.voxang(ii,1), '%3.1f') ', ' num2str(MRS_struct.p.voxang(ii,3), '%3.1f') '] deg'];
         else
             str = [' [' num2str(MRS_struct.p.voxang(ii,1), '%3.1f') ', ' num2str(MRS_struct.p.voxang(ii,2), '%3.1f') ', ' num2str(MRS_struct.p.voxang(ii,3), '%3.1f') '] deg'];
         end
-        text(0.5, 0.15, 'Angulation: ', 'Units', 'normalized', 'HorizontalAlignment', 'right', 'FontName', 'Arial', 'FontSize', 13);
-        text(0.5, 0.15, str, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13);
+        text(0.5, 0.15, 'Angulation: ', 'Units', 'normalized', 'HorizontalAlignment', 'right', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj);
+        text(0.5, 0.15, str, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj);
 
-        text(0.5, 0.03, 'CoRegVer: ', 'Units', 'normalized', 'HorizontalAlignment', 'right', 'FontName', 'Arial', 'FontSize', 13);
-        text(0.5, 0.03, [' ' MRS_struct.info.version.coreg], 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13);
+        text(0.5, 0.03, 'CoRegVer: ', 'Units', 'normalized', 'HorizontalAlignment', 'right', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj);
+        text(0.5, 0.03, [' ' MRS_struct.info.version.coreg], 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj);
 
         hb = subplot(2,3,1:3);
 
@@ -237,14 +243,14 @@ for ii = 1:MRS_struct.p.numScans
 
         imagesc(MRS_struct.mask.(vox{kk}).img{ii});
         axis equal tight off;
-        text(0.01, 0.5, 'L', 'Color', [1 1 1], 'FontSize', 20, 'Units', 'normalized');
-        text(0.16, 0.95, 'A', 'Color', [1 1 1], 'FontSize', 20, 'Units', 'normalized');
-        text(0.32, 0.5, 'A', 'Color', [1 1 1], 'FontSize', 20, 'Units', 'normalized');
-        text(0.5, 0.95, 'S', 'Color', [1 1 1], 'FontSize', 20, 'Units', 'normalized');
-        text(0.825, 0.95, 'S', 'Color', [1 1 1], 'FontSize', 20, 'Units', 'normalized');
-        text(0.975, 0.5, 'R', 'Color', [1 1 1], 'FontSize', 20, 'Units', 'normalized');
+        text(0.01, 0.5, 'L', 'Color', [1 1 1], 'FontSize', 20 - font_size_adj, 'Units', 'normalized');
+        text(0.16, 0.95, 'A', 'Color', [1 1 1], 'FontSize', 20 - font_size_adj, 'Units', 'normalized');
+        text(0.32, 0.5, 'A', 'Color', [1 1 1], 'FontSize', 20 - font_size_adj, 'Units', 'normalized');
+        text(0.5, 0.95, 'S', 'Color', [1 1 1], 'FontSize', 20 - font_size_adj, 'Units', 'normalized');
+        text(0.825, 0.95, 'S', 'Color', [1 1 1], 'FontSize', 20 - font_size_adj, 'Units', 'normalized');
+        text(0.975, 0.5, 'R', 'Color', [1 1 1], 'FontSize', 20 - font_size_adj, 'Units', 'normalized');
         set(hb,'Position',[0 0.15 1 1]);
-        title(t, 'FontName', 'Arial', 'FontSize', 15, 'Interpreter', 'none');
+        title(t, 'FontName', 'Arial', 'FontSize', 15 - font_size_adj, 'Interpreter', 'none');
 
         % Save output as PDF
         run_count = SavePDF(h, MRS_struct, ii, 1, kk, vox, mfilename, run_count);

--- a/GannetFit.m
+++ b/GannetFit.m
@@ -12,7 +12,15 @@ if ~isstruct(MRS_struct)
 end
 
 MRS_struct.info.datetime.fit = datetime('now');
-MRS_struct.info.version.fit = '250913';
+MRS_struct.info.version.fit = '250914';
+
+if ~isMATLABReleaseOlderThan("R2025a") && MRS_struct.p.append
+    font_size_adj  = 2.75;
+    font_size_adj2 = 1.5;
+else
+    font_size_adj  = 0;
+    font_size_adj2 = 0;
+end
 
 if MRS_struct.p.PRIAM
     vox = MRS_struct.p.vox;
@@ -617,7 +625,7 @@ for kk = 1:length(vox)
                             freq(freqbounds), residPlot2, 'k');
                         plot(freq(freqbounds(ChoRange)), residPlot(ChoRange), 'Color', [255 160 64]/255);
                         hold off;
-                        set(gca,'XLim',[2.6 3.6]);
+                        set(gca, 'XLim', [2.6 3.6], 'FontSize', 10 - font_size_adj);
                         
                     case 'GSH'
                         residPlot = residPlot + metabmin - max(residPlot);
@@ -635,7 +643,7 @@ for kk = 1:length(vox)
                                 freq(freqbounds), GSHgaussModel(GaussModelParam,freq(freqbounds)), 'r', ...
                                 freq(freqbounds), residPlot2, 'k');
                         end
-                        set(gca, 'XLim', [1.8 4.2]);
+                        set(gca, 'XLim', [1.8 4.2], 'FontSize', 10 - font_size_adj);
                         
                     case 'Lac'
                         hold on;
@@ -645,13 +653,13 @@ for kk = 1:length(vox)
                         p4 = plot(freq(freqbounds), LacModel(LacPlusModelParam,freq(freqbounds)), 'r', 'LineWidth', 1);
                         p5 = plot(freq(freqbounds), resid, 'k');
                         hold off;
-                        set(gca, 'XLim', [0.7 1.9], 'XTick', 0:0.25:10);
+                        set(gca, 'XLim', [0.7 1.9], 'XTick', 0:0.25:10, 'FontSize', 10 - font_size_adj);
                         
                     case 'Glx'
                         plot(freq(plotbounds), real(DIFF(ii,plotbounds)), 'b', ...
                             freq(freqbounds), DoubleGaussModel(GaussModelParam,freq(freqbounds)), 'r', ...
                             freq(freqbounds), resid, 'k');
-                        set(gca,'XLim',[3.4 4.2]);
+                        set(gca, 'XLim', [3.4 4.2], 'FontSize', 10 - font_size_adj);
                         
                     case 'GABAGlx'
                         residPlot  = residPlot + metabmin - max(residPlot);
@@ -669,7 +677,7 @@ for kk = 1:length(vox)
                             plot(freq(freqbounds(ChoRange)), residPlot(ChoRange), 'Color', [255 160 64]/255);
                         end
                         hold off;
-                        set(gca,'XLim',[2.7 4.2]);
+                        set(gca, 'XLim', [2.7 4.2], 'FontSize', 10 - font_size_adj);
                         
                     case 'EtOH'
                         residPlot = residPlot + metabmin - max(residPlot);
@@ -681,80 +689,84 @@ for kk = 1:length(vox)
                             freq(freqbounds), residPlot2, 'k');
                         plot(freq(freqbounds(LacRange)), residPlot(LacRange), 'Color', [255 160 64]/255);
                         hold off;
-                        set(gca,'XLim',[0.4 1.9]);
+                        set(gca, 'XLim', [0.4 1.9], 'FontSize', 10 - font_size_adj);
                 end
                 
                 % From here on is cosmetic - adding labels etc.
                 switch target{jj}
                     case 'GABA'
-                        text(3, metabmax/4, target{jj}, 'HorizontalAlignment', 'center');
+                        text(3, metabmax/4, target{jj}, 'HorizontalAlignment', 'center', 'FontSize', 10 - font_size_adj);
                         labelbounds = freq <= 2.4 & freq >= 2;
                         tailtop = max(real(DIFF(ii,labelbounds)));
                         tailbottom = min(real(DIFF(ii,labelbounds)));
-                        text(2.8, min(resid), 'residual', 'HorizontalAlignment', 'left');
-                        text(2.8, tailtop + metabmax/20, 'data', 'Color', [0 0 1]);
-                        text(2.8, tailbottom - metabmax/20, 'model', 'Color', [1 0 0]);
+                        text(2.8, min(resid), 'residual', 'HorizontalAlignment', 'left', 'FontSize', 10 - font_size_adj);
+                        text(2.8, tailtop + metabmax/20, 'data', 'Color', [0 0 1], 'FontSize', 10 - font_size_adj);
+                        text(2.8, tailbottom - metabmax/20, 'model', 'Color', [1 0 0], 'FontSize', 10 - font_size_adj);
                         if length(MRS_struct.p.target) ~= 3
-                            text(3.2, min(residPlot) - 0.5*abs(max(residPlot)), 'down-weighted', 'Color', [255 160 64]/255, 'HorizontalAlignment', 'center');
+                            text(3.2, min(residPlot) - 0.5*abs(max(residPlot)), 'down-weighted', 'Color', [255 160 64]/255, ...
+                                'HorizontalAlignment', 'center', 'FontSize', 10 - font_size_adj);
                         end
                         
                     case 'GSH'
-                        text(2.95, maxinGSH+maxinGSH/4, target{jj}, 'HorizontalAlignment', 'center');
+                        text(2.95, maxinGSH+maxinGSH/4, target{jj}, 'HorizontalAlignment', 'center', 'FontSize', 10 - font_size_adj);
                         labelbounds = freq <= 2.4 & freq >= 1.75;
                         tailtop = max(real(DIFF(ii,labelbounds)));
                         tailbottom = min(real(DIFF(ii,labelbounds)));
-                        text(2.25, min(resid), 'residual', 'HorizontalAlignment', 'left');
-                        text(2.25, tailtop + metabmax/20, 'data', 'Color', [0 0 1]);
-                        text(2.45, tailbottom - 20*metabmax/20, 'model', 'Color', [1 0 0]);
+                        text(2.25, min(resid), 'residual', 'HorizontalAlignment', 'left', 'FontSize', 10 - font_size_adj);
+                        text(2.25, tailtop + metabmax/20, 'data', 'Color', [0 0 1], 'FontSize', 10 - font_size_adj);
+                        text(2.45, tailbottom - 20*metabmax/20, 'model', 'Color', [1 0 0], 'FontSize', 10 - font_size_adj);
                         if length(MRS_struct.p.target) == 3 && all(ismember(MRS_struct.p.target,{'EtOH','GABA','GSH'}))
-                            text(3.3, max(residPlot) + 0.5*abs(max(residPlot) - min(residPlot)), 'down-weighted', 'Color', [255 160 64]/255, 'HorizontalAlignment', 'right');
+                            text(3.3, max(residPlot) + 0.5*abs(max(residPlot) - min(residPlot)), 'down-weighted', 'Color', [255 160 64]/255, ...
+                                'HorizontalAlignment', 'right', 'FontSize', 10 - font_size_adj);
                         end
                         
                     case 'Lac'
-%                         text(1.27, metabmax/3.5, 'Lac+', 'HorizontalAlignment', 'center');
+%                         text(1.27, metabmax/3.5, 'Lac+', 'HorizontalAlignment', 'center', 'FontSize', 10 - font_size_adj);
 %                         labelbounds = freq <= 0.8 & freq >= 0.42;
 %                         tailtop = max(real(DIFF(ii,labelbounds)));
 %                         tailbottom = min(real(DIFF(ii,labelbounds)));
-%                         text(0.44, mean(real(DIFF(ii,labelbounds))) + 4*std(real(DIFF(ii,labelbounds))), 'data', 'HorizontalAlignment', 'right');
-%                         text(0.44, mean(resid) - 4*std(resid), 'residual', 'HorizontalAlignment', 'right');
-%                         text(0.85, tailbottom, 'model', 'Color', [1 0 0]);
-                        legend([p1, p2, p3, p4, p5], {'data','BHB+','Lac+','model','residual'}, 'box', 'off', 'Location', 'northeast');
+%                         text(0.44, mean(real(DIFF(ii,labelbounds))) + 4*std(real(DIFF(ii,labelbounds))), 'data', 'HorizontalAlignment', 'right', 'FontSize', 10 - font_size_adj);
+%                         text(0.44, mean(resid) - 4*std(resid), 'residual', 'HorizontalAlignment', 'right', 'FontSize', 10 - font_size_adj);
+%                         text(0.85, tailbottom, 'model', 'Color', [1 0 0], 'FontSize', 10 - font_size_adj);
+                        legend([p1, p2, p3, p4, p5], {'data','BHB+','Lac+','model','residual'}, 'box', 'off', 'Location', 'northeast', 'FontSize', 9 - font_size_adj);
                         
                     case 'Glx'
-                        text(3.8, metabmax/4, target{jj}, 'HorizontalAlignment', 'center');
+                        text(3.8, metabmax/4, target{jj}, 'HorizontalAlignment', 'center', 'FontSize', 10 - font_size_adj);
                         labelbounds = freq <= 3.6 & freq >= 3.4;
                         tailtop = max(real(DIFF(ii,labelbounds)));
                         tailbottom = min(real(DIFF(ii,labelbounds)));
-                        text(3.5, min(resid),'residual', 'HorizontalAlignment', 'left');
-                        text(3.5, tailtop + metabmax/20, 'data', 'Color', [0 0 1]);
-                        text(3.5, tailbottom - metabmax/20, 'model', 'Color', [1 0 0]);
+                        text(3.5, min(resid),'residual', 'HorizontalAlignment', 'left', 'FontSize', 10 - font_size_adj);
+                        text(3.5, tailtop + metabmax/20, 'data', 'Color', [0 0 1], 'FontSize', 10 - font_size_adj);
+                        text(3.5, tailbottom - metabmax/20, 'model', 'Color', [1 0 0], 'FontSize', 10 - font_size_adj);
                         
                     case 'GABAGlx'
-                        text(3, metabmax/4, 'GABA', 'HorizontalAlignment', 'center');
-                        text(3.755, metabmax/4, 'Glx', 'HorizontalAlignment', 'center');
-                        text(2.8, min(resid), 'residual', 'HorizontalAlignment', 'left');
+                        text(3, metabmax/4, 'GABA', 'HorizontalAlignment', 'center', 'FontSize', 10 - font_size_adj);
+                        text(3.755, metabmax/4, 'Glx', 'HorizontalAlignment', 'center', 'FontSize', 10 - font_size_adj);
+                        text(2.8, min(resid), 'residual', 'HorizontalAlignment', 'left', 'FontSize', 10 - font_size_adj);
                         labelbounds = freq <= 2.8 & freq >= 2.7;
                         tailtop = max(real(DIFF(ii,labelbounds)));
                         tailbottom = min(real(DIFF(ii,labelbounds)));
-                        text(2.8, tailtop + metabmax/20, 'data', 'Color', [0 0 1]);
-                        text(2.8, tailbottom - metabmax/20, 'model', 'Color', [1 0 0]);
-                        text(3.2, min(residPlot) - 0.5*abs(max(residPlot)), 'down-weighted', 'Color', [255 160 64]/255, 'HorizontalAlignment', 'center');
+                        text(2.8, tailtop + metabmax/20, 'data', 'Color', [0 0 1], 'FontSize', 10 - font_size_adj);
+                        text(2.8, tailbottom - metabmax/20, 'model', 'Color', [1 0 0], 'FontSize', 10 - font_size_adj);
+                        text(3.2, min(residPlot) - 0.5*abs(max(residPlot)), 'down-weighted', 'Color', [255 160 64]/255, ...
+                            'HorizontalAlignment', 'center', 'FontSize', 10 - font_size_adj);
                         
                     case 'EtOH'
-                        text(1.45, metabmax/4, target{jj}, 'HorizontalAlignment', 'center');
+                        text(1.45, metabmax/4, target{jj}, 'HorizontalAlignment', 'center', 'FontSize', 10 - font_size_adj);
                         labelbounds = freq <= 0.9 & freq >= 0.5;
                         tailtop = max(real(DIFF(ii,labelbounds)));
                         tailbottom = min(real(DIFF(ii,labelbounds)));
-                        text(0.6, min(resid),'residual', 'HorizontalAlignment', 'left');
-                        text(0.8, tailtop + metabmax/20, 'data', 'Color', [0 0 1]);
-                        text(0.8, tailbottom - metabmax/20, 'model', 'Color', [1 0 0]);
-                        text(1.4, max(residPlot2) + 0.5*abs(max(residPlot2)), 'down-weighted', 'Color', [255 160 64]/255, 'HorizontalAlignment', 'center');
+                        text(0.6, min(resid),'residual', 'HorizontalAlignment', 'left', 'FontSize', 10 - font_size_adj);
+                        text(0.8, tailtop + metabmax/20, 'data', 'Color', [0 0 1], 'FontSize', 10 - font_size_adj);
+                        text(0.8, tailbottom - metabmax/20, 'model', 'Color', [1 0 0], 'FontSize', 10 - font_size_adj);
+                        text(1.4, max(residPlot2) + 0.5*abs(max(residPlot2)), 'down-weighted', 'Color', [255 160 64]/255, ...
+                            'HorizontalAlignment', 'center', 'FontSize', 10 - font_size_adj);
                 end
                 
-                title('Difference spectrum and model fit');
-                xlabel('ppm');
-                set(gca,'XDir','reverse','TickDir','out','Box','off');
-                set(get(gca,'YAxis'),'Visible','off');
+                title('Difference spectrum and model fit', 'FontSize', 11 - font_size_adj);
+                xlabel('ppm', 'FontSize', 11 - font_size_adj);
+                set(gca, 'XDir', 'reverse', 'TickDir', 'out', 'Box', 'off', 'FontSize', 10 - font_size_adj);
+                set(get(gca,'YAxis'), 'Visible', 'off');
                 
                 
                 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -824,17 +836,17 @@ for kk = 1:length(vox)
                     plot(freq(freqbounds), real(WaterData(ii,freqbounds)), 'b', ...
                         freq(freqbounds), real(LorentzGaussModelP(LGPModelParam,freq(freqbounds))), 'r', ...
                         freq(freqbounds), residw, 'k');
-                    set(gca,'XDir','reverse','TickDir','out','Box','off','XTick',4.2:0.2:5.2);
+                    set(gca, 'XDir', 'reverse', 'TickDir', 'out', 'Box', 'off', 'XTick', 4.2:0.2:5.2, 'FontSize', 10 - font_size_adj);
                     xlim([4.2 5.2]);
                     set(get(gca,'YAxis'),'Visible','off');
                     % Add on some labels
-                    text(4.8, watmax/2, 'Water', 'HorizontalAlignment', 'right');
+                    text(4.8, watmax/2, 'Water', 'HorizontalAlignment', 'right', 'FontSize', 10 - font_size_adj);
                     labelfreq = freq(freqbounds);
                     rlabelbounds = labelfreq <= 4.4 & labelfreq >= 4.25;
                     axis_bottom = axis;
-                    text(4.4, max(min(residw(rlabelbounds)) - 0.05 * watmax, axis_bottom(3)), 'residual', 'HorizontalAlignment', 'left');
-                    xlabel('ppm');
-                    title('Reference signals');
+                    text(4.4, max(min(residw(rlabelbounds)) - 0.05 * watmax, axis_bottom(3)), 'residual', 'HorizontalAlignment', 'left', 'FontSize', 10 - font_size_adj);
+                    xlabel('ppm', 'FontSize', 11 - font_size_adj);
+                    title('Reference signals', 'FontSize', 11 - font_size_adj);
                     
                     % Root sum square fit error and concentration in institutional units
                     switch target{jj}
@@ -1152,35 +1164,34 @@ for kk = 1:length(vox)
                 resmaxCr = max(residCr);
                 residCr = residCr + Crmin - resmaxCr;
                 if strcmp(MRS_struct.p.reference,'H2O')
-                    hb_pos = get(hb,'Position');
+                    hb_pos = get(hb, 'Position');
                     hd = axes(hb.Parent, 'Position', [1.3*hb_pos(1)+hb_pos(3)-0.175, 1.001*hb_pos(2)+hb_pos(4)-0.175 0.1125 0.1575]);
                     plot(freq, real(Cr_OFF), 'b', ...
                         freq(freqboundsChoCr), real(TwoLorentzModel(MRS_struct.out.(vox{kk}).ChoCr.ModelParam(ii,:),freq(freqboundsChoCr))), 'r', ...
                         freq(freqboundsChoCr), real(TwoLorentzModel([MRS_struct.out.(vox{kk}).ChoCr.ModelParam(ii,1:(end-1)) 0],freq(freqboundsChoCr))), 'r', ...
                         freq(freqboundsCr), residCr, 'k');
-                    text(2.94, Crmax*0.75, 'Creatine', 'HorizontalAlignment', 'left', 'FontSize', 10);
-                    set(gca,'XDir','reverse','TickDir','out','Box','off','XLim',[2.6 3.6],'XTick',2.6:0.2:3.6,'FontSize',6);
-                    xlabel('ppm');
-                    set(get(gca,'YAxis'),'Visible','off');
-                    hd_pos = get(hd,'Position');
-                    set(hd,'Position',[hb_pos(1)+hb_pos(3)-hd_pos(3) hd_pos(2:4)]);
+                    text(2.94, Crmax*0.75, 'Creatine', 'HorizontalAlignment', 'left', 'FontSize', 10 - font_size_adj2);
+                    set(gca, 'XDir', 'reverse', 'TickDir', 'out', 'Box', 'off', 'XLim', [2.6 3.6], 'XTick', 2.6:0.2:3.6, 'FontSize', 6 - font_size_adj2);
+                    xlabel('ppm', 'FontSize', 11 - font_size_adj);
+                    set(get(gca,'YAxis'), 'Visible', 'off');
+                    hd_pos = get(hd, 'Position');
+                    set(hd, 'Position', [hb_pos(1)+hb_pos(3)-hd_pos(3) hd_pos(2:4)]);
                 else
                     hb = subplot(2,2,3);
                     plot(freq, real(Cr_OFF), 'b', ...
                         freq(freqboundsChoCr), real(TwoLorentzModel(MRS_struct.out.(vox{kk}).ChoCr.ModelParam(ii,:),freq(freqboundsChoCr))), 'r', ...
                         freq(freqboundsChoCr), real(TwoLorentzModel([MRS_struct.out.(vox{kk}).ChoCr.ModelParam(ii,1:(end-1)) 0],freq(freqboundsChoCr))), 'r', ...
                         freq(freqboundsCr), residCr, 'k');
-                    set(gca,'XDir','reverse','TickDir','out','Box','off','XTick',2.6:0.2:3.6);
+                    set(gca,'XDir', 'reverse', 'TickDir', 'out', 'Box', 'off', 'XTick', 2.6:0.2:3.6, 'FontSize', 10 - font_size_adj);
                     set(get(gca,'YAxis'),'Visible','off');
                     xlim([2.6 3.6]);
-                    crlabelbounds = freq(freqboundsCr) <= 3.12 & freq(freqboundsCr) >= 2.72;
-                    hcres = text(3, max(residCr(crlabelbounds)) + 0.05*Crmax, 'residual');
-                    set(hcres,'HorizontalAlignment', 'center');
-                    text(2.7,0.1*Crmax,'data','Color',[0 0 1]);
-                    text(2.7,0.01*Crmax,'model','Color',[1 0 0]);
-                    text(2.94,Crmax*0.75,'Creatine');
-                    xlabel('ppm');
-                    title('Reference signal');
+                    Crlabelbounds = freq(freqboundsCr) <= 3.12 & freq(freqboundsCr) >= 2.72;
+                    text(3, max(residCr(Crlabelbounds)) + 0.05*Crmax, 'residual', 'HorizontalAlignment', 'center', 'FontSize', 10 - font_size_adj);
+                    text(2.7, 0.1*Crmax, 'data', 'Color', [0 0 1], 'FontSize', 10 - font_size_adj);
+                    text(2.7, 0.01*Crmax, 'model','Color', [1 0 0], 'FontSize', 10 - font_size_adj);
+                    text(2.94, Crmax*0.75, 'Creatine', 'FontSize', 10 - font_size_adj);
+                    xlabel('ppm', 'FontSize', 11 - font_size_adj);
+                    title('Reference signal', 'FontSize', 11 - font_size_adj);
                 end
                 
                 if any(strcmp('mask',fieldnames(MRS_struct)))
@@ -1214,15 +1225,16 @@ for kk = 1:length(vox)
                 else
                     shift2 = 0;
                 end
-                text(0.4, text_pos, 'Filename: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
+                text(0.4, text_pos, 'Filename: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
                 if MRS_struct.p.join
-                    text(0.425, text_pos+shift2, [fname ' (+ ' num2str(MRS_struct.p.numFilesPerScan - 1) ' more)'], 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'Interpreter', 'none');
+                    text(0.425, text_pos+shift2, [fname ' (+ ' num2str(MRS_struct.p.numFilesPerScan - 1) ' more)'], ...
+                        'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'Interpreter', 'none');
                 else
-                    text(0.425, text_pos+shift2, fname, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'Interpreter', 'none');
+                    text(0.425, text_pos+shift2, fname, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'Interpreter', 'none');
                 end
                 
                 % 2a. Area
-                text(0.4, text_pos-shift, 'Area ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'FontWeight', 'bold', 'HorizontalAlignment', 'right');
+                text(0.4, text_pos-shift, 'Area ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'FontWeight', 'bold', 'HorizontalAlignment', 'right');
                 
                 switch target{jj}
                     case 'GABA'
@@ -1247,12 +1259,12 @@ for kk = 1:length(vox)
                         str2 = sprintf('%.3g', MRS_struct.out.(vox{kk}).(target{jj}).Area(ii));
                 end
                 
-                text(0.4, text_pos-2*shift, str1, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-                text(0.425, text_pos-2*shift, str2, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
+                text(0.4, text_pos-2*shift, str1, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+                text(0.425, text_pos-2*shift, str2, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
                 
                 if strcmp(target{jj},'GABAGlx')
-                    text(0.4, text_pos-3*shift, str3, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-                    text(0.425, text_pos-3*shift, str4, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
+                    text(0.4, text_pos-3*shift, str3, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+                    text(0.425, text_pos-3*shift, str4, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
                     n = 0;
                 else
                     n = shift;
@@ -1264,33 +1276,33 @@ for kk = 1:length(vox)
                     str1 = sprintf('%.3g', MRS_struct.out.(vox{kk}).water.Area(ii));
                     str2 = sprintf('%.3g', MRS_struct.out.(vox{kk}).Cr.Area(ii));
                     
-                    text(0.4, text_pos-4*shift+n, 'Water: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-                    text(0.425, text_pos-4*shift+n, str1, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
-                    text(0.4, text_pos-5*shift+n, 'Cr: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-                    text(0.425, text_pos-5*shift+n, str2, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
+                    text(0.4, text_pos-4*shift+n, 'Water: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+                    text(0.425, text_pos-4*shift+n, str1, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
+                    text(0.4, text_pos-5*shift+n, 'Cr: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+                    text(0.425, text_pos-5*shift+n, str2, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
                     
                     % 3. Linewidth
-                    text(0.4, text_pos-6*shift+n, 'Linewidth ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'FontWeight', 'bold', 'HorizontalAlignment', 'right');
+                    text(0.4, text_pos-6*shift+n, 'Linewidth ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'FontWeight', 'bold', 'HorizontalAlignment', 'right');
                     
                     str1 = sprintf('%.2f Hz', MRS_struct.out.(vox{kk}).water.FWHM(ii));
                     str2 = sprintf('%.2f Hz', MRS_struct.out.(vox{kk}).Cr.FWHM(ii));
-                    text(0.4, text_pos-7*shift+n, 'Water: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-                    text(0.425, text_pos-7*shift+n, str1, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
-                    text(0.4, text_pos-8*shift+n, 'Cr: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-                    text(0.425, text_pos-8*shift+n, str2, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
+                    text(0.4, text_pos-7*shift+n, 'Water: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+                    text(0.425, text_pos-7*shift+n, str1, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
+                    text(0.4, text_pos-8*shift+n, 'Cr: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+                    text(0.425, text_pos-8*shift+n, str2, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
                                         
                     % 4. SNR
-                    text(0.4, text_pos-9*shift+n, 'SNR ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'FontWeight', 'bold', 'HorizontalAlignment', 'right');
+                    text(0.4, text_pos-9*shift+n, 'SNR ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'FontWeight', 'bold', 'HorizontalAlignment', 'right');
                     
                     str1 = sprintf('%.0f', MRS_struct.out.(vox{kk}).water.SNR(ii));
                     str2 = sprintf('%.0f', MRS_struct.out.(vox{kk}).Cr.SNR(ii));
-                    text(0.4, text_pos-10*shift+n, 'Water: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-                    text(0.425, text_pos-10*shift+n, str1, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
-                    text(0.4, text_pos-11*shift+n, 'Cr: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-                    text(0.425, text_pos-11*shift+n, str2, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
+                    text(0.4, text_pos-10*shift+n, 'Water: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+                    text(0.425, text_pos-10*shift+n, str1, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
+                    text(0.4, text_pos-11*shift+n, 'Cr: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+                    text(0.425, text_pos-11*shift+n, str2, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
                     
                     % 5a. Fit Error
-                    text(0.4, text_pos-12*shift+n, 'Fit error ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'FontWeight', 'bold', 'HorizontalAlignment', 'right');
+                    text(0.4, text_pos-12*shift+n, 'Fit error ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'FontWeight', 'bold', 'HorizontalAlignment', 'right');
                     
                     switch target{jj}
                         
@@ -1310,13 +1322,13 @@ for kk = 1:length(vox)
                             str3 = sprintf('%.2f%%', MRS_struct.out.(vox{kk}).(target{jj}).FitError_W(ii));
                             str4 = sprintf('%.2f%%', MRS_struct.out.(vox{kk}).(target{jj}).FitError_Cr(ii));
                             
-                            text(0.4, text_pos-13*shift+n, str1, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-                            text(0.425, text_pos-13*shift+n, str3, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
-                            text(0.4, text_pos-14*shift+n, str2, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-                            text(0.425, text_pos-14*shift+n, str4, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
+                            text(0.4, text_pos-13*shift+n, str1, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+                            text(0.425, text_pos-13*shift+n, str3, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
+                            text(0.4, text_pos-14*shift+n, str2, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+                            text(0.425, text_pos-14*shift+n, str4, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
                             
                             % 6. Quantification
-                            text(0.4, text_pos-15*shift+n, 'Quantification ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'FontWeight', 'bold', 'HorizontalAlignment', 'right');
+                            text(0.4, text_pos-15*shift+n, 'Quantification ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'FontWeight', 'bold', 'HorizontalAlignment', 'right');
                             
                             if strcmpi(target{jj},'GABA')
                                 str1 = 'GABA+/Water: ';
@@ -1331,10 +1343,10 @@ for kk = 1:length(vox)
                             str3 = sprintf('%.2f i.u.', MRS_struct.out.(vox{kk}).(target{jj}).ConcIU(ii));
                             str4 = sprintf('%.2f', MRS_struct.out.(vox{kk}).(target{jj}).ConcCr(ii));
                             
-                            text(0.4, text_pos-16*shift+n, str1, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-                            text(0.425, text_pos-16*shift+n, str3, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
-                            text(0.4, text_pos-17*shift+n, str2, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-                            text(0.425, text_pos-17*shift+n, str4, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
+                            text(0.4, text_pos-16*shift+n, str1, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+                            text(0.425, text_pos-16*shift+n, str3, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
+                            text(0.4, text_pos-17*shift+n, str2, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+                            text(0.425, text_pos-17*shift+n, str4, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
                             
                             n = 5*shift;
                             
@@ -1350,17 +1362,17 @@ for kk = 1:length(vox)
                             str7 = sprintf('%.2f%%', MRS_struct.out.(vox{kk}).Glx.FitError_W(ii));
                             str8 = sprintf('%.2f%%', MRS_struct.out.(vox{kk}).Glx.FitError_Cr(ii));
                             
-                            text(0.4, text_pos-13*shift, str1, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-                            text(0.425, text_pos-13*shift, str3, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
-                            text(0.4, text_pos-14*shift, str2, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-                            text(0.425, text_pos-14*shift, str4, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
-                            text(0.4, text_pos-15*shift, str5, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-                            text(0.425, text_pos-15*shift, str7, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
-                            text(0.4, text_pos-16*shift, str6, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-                            text(0.425, text_pos-16*shift, str8, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
+                            text(0.4, text_pos-13*shift, str1, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+                            text(0.425, text_pos-13*shift, str3, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
+                            text(0.4, text_pos-14*shift, str2, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+                            text(0.425, text_pos-14*shift, str4, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
+                            text(0.4, text_pos-15*shift, str5, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+                            text(0.425, text_pos-15*shift, str7, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
+                            text(0.4, text_pos-16*shift, str6, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+                            text(0.425, text_pos-16*shift, str8, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
                             
                             % 6. Quantification
-                            text(0.4, text_pos-17*shift, 'Quantification ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'FontWeight', 'bold', 'HorizontalAlignment', 'right');
+                            text(0.4, text_pos-17*shift, 'Quantification ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'FontWeight', 'bold', 'HorizontalAlignment', 'right');
                             
                             str1 = 'GABA+/Water: ';
                             str2 = sprintf('%.2f i.u.', MRS_struct.out.(vox{kk}).GABA.ConcIU(ii));
@@ -1371,47 +1383,47 @@ for kk = 1:length(vox)
                             str7 = 'Glx/Cr: ';
                             str8 = sprintf('%.2f', MRS_struct.out.(vox{kk}).Glx.ConcCr(ii));
                             
-                            text(0.4, text_pos-18*shift, str1, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-                            text(0.425, text_pos-18*shift, str2, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
-                            text(0.4, text_pos-19*shift, str3, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-                            text(0.425, text_pos-19*shift, str4, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
-                            text(0.4, text_pos-20*shift, str5, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-                            text(0.425, text_pos-20*shift, str6, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
-                            text(0.4, text_pos-21*shift, str7, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-                            text(0.425, text_pos-21*shift, str8, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
+                            text(0.4, text_pos-18*shift, str1, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+                            text(0.425, text_pos-18*shift, str2, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
+                            text(0.4, text_pos-19*shift, str3, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+                            text(0.425, text_pos-19*shift, str4, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
+                            text(0.4, text_pos-20*shift, str5, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+                            text(0.425, text_pos-20*shift, str6, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
+                            text(0.4, text_pos-21*shift, str7, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+                            text(0.425, text_pos-21*shift, str8, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
                             
                             n = 0;
                             
                     end
                     
                     % 7. FitVer
-                    text(0.4, text_pos-22.5*shift+n, 'FitVer: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-                    text(0.425, text_pos-22.5*shift+n, MRS_struct.info.version.fit, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
+                    text(0.4, text_pos-22.5*shift+n, 'FitVer: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+                    text(0.425, text_pos-22.5*shift+n, MRS_struct.info.version.fit, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
                     
                 else
                     
                     % 2. Area (Cr)
                     str = sprintf('%.3g', MRS_struct.out.(vox{kk}).Cr.Area(ii));
                     
-                    text(0.4, text_pos-4*shift+n, 'Cr: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-                    text(0.425, text_pos-4*shift+n, str, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
+                    text(0.4, text_pos-4*shift+n, 'Cr: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+                    text(0.425, text_pos-4*shift+n, str, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
                     
                     % 3. Linewidth
-                    text(0.4, text_pos-5*shift+n, 'Linewidth ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'FontWeight', 'bold', 'HorizontalAlignment', 'right');
+                    text(0.4, text_pos-5*shift+n, 'Linewidth ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'FontWeight', 'bold', 'HorizontalAlignment', 'right');
                     
                     str = sprintf('%.2f Hz', MRS_struct.out.(vox{kk}).Cr.FWHM(ii));
-                    text(0.4, text_pos-6*shift+n, 'Cr: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-                    text(0.425, text_pos-6*shift+n, str, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
+                    text(0.4, text_pos-6*shift+n, 'Cr: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+                    text(0.425, text_pos-6*shift+n, str, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
                     
                     % 4. SNR
-                    text(0.4, text_pos-7*shift+n, 'SNR ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'FontWeight', 'bold', 'HorizontalAlignment', 'right');
+                    text(0.4, text_pos-7*shift+n, 'SNR ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'FontWeight', 'bold', 'HorizontalAlignment', 'right');
                     
                     str = sprintf('%.0f', MRS_struct.out.(vox{kk}).Cr.SNR(ii));
-                    text(0.4, text_pos-8*shift+n, 'Cr: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-                    text(0.425, text_pos-8*shift+n, str, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
+                    text(0.4, text_pos-8*shift+n, 'Cr: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+                    text(0.425, text_pos-8*shift+n, str, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
                                         
                     % 5a. Fit Error
-                    text(0.4, text_pos-9*shift+n, 'Fit error ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'FontWeight', 'bold', 'HorizontalAlignment', 'right');
+                    text(0.4, text_pos-9*shift+n, 'Fit error ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'FontWeight', 'bold', 'HorizontalAlignment', 'right');
                     
                     switch target{jj}
                         
@@ -1427,11 +1439,11 @@ for kk = 1:length(vox)
                             end
                             str2 = sprintf('%.2f%%', MRS_struct.out.(vox{kk}).(target{jj}).FitError_Cr(ii));
                             
-                            text(0.4, text_pos-10*shift+n, str1, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-                            text(0.425, text_pos-10*shift+n, str2, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
+                            text(0.4, text_pos-10*shift+n, str1, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+                            text(0.425, text_pos-10*shift+n, str2, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
                             
                             % 5. Quantification
-                            text(0.4, text_pos-11*shift+n, 'Quantification ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'FontWeight', 'bold', 'HorizontalAlignment', 'right');
+                            text(0.4, text_pos-11*shift+n, 'Quantification ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'FontWeight', 'bold', 'HorizontalAlignment', 'right');
                             
                             if strcmpi(target{jj},'GABA')
                                 str1 = 'GABA+/Cr: ';
@@ -1442,8 +1454,8 @@ for kk = 1:length(vox)
                             end
                             str2 = sprintf('%.2f', MRS_struct.out.(vox{kk}).(target{jj}).ConcCr(ii));
                             
-                            text(0.4, text_pos-12*shift+n, str1, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-                            text(0.425, text_pos-12*shift+n, str2, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
+                            text(0.4, text_pos-12*shift+n, str1, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+                            text(0.425, text_pos-12*shift+n, str2, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
                             
                             n = 3*shift;
                             
@@ -1455,31 +1467,31 @@ for kk = 1:length(vox)
                             str3 = 'Glx,Cr: ';
                             str4 = sprintf('%.2f%%', MRS_struct.out.(vox{kk}).Glx.FitError_Cr(ii));
                             
-                            text(0.4, text_pos-10*shift, str1, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-                            text(0.425, text_pos-10*shift, str2, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
-                            text(0.4, text_pos-11*shift, str3, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-                            text(0.425, text_pos-11*shift, str4, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
+                            text(0.4, text_pos-10*shift, str1, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+                            text(0.425, text_pos-10*shift, str2, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
+                            text(0.4, text_pos-11*shift, str3, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+                            text(0.425, text_pos-11*shift, str4, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
                             
                             % 5. Quantification
-                            text(0.4, text_pos-12*shift, 'Quantification ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'FontWeight', 'bold', 'HorizontalAlignment', 'right');
+                            text(0.4, text_pos-12*shift, 'Quantification ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'FontWeight', 'bold', 'HorizontalAlignment', 'right');
                             
                             str1 = 'GABA+/Cr: ';
                             str2 = sprintf('%.2f', MRS_struct.out.(vox{kk}).GABA.ConcCr(ii));
                             str3 = 'Glx/Cr: ';
                             str4 = sprintf('%.2f', MRS_struct.out.(vox{kk}).Glx.ConcCr(ii));
                             
-                            text(0.4, text_pos-13*shift, str1, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-                            text(0.425, text_pos-13*shift, str2, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
-                            text(0.4, text_pos-14*shift, str3, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-                            text(0.425, text_pos-14*shift, str4, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
+                            text(0.4, text_pos-13*shift, str1, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+                            text(0.425, text_pos-13*shift, str2, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
+                            text(0.4, text_pos-14*shift, str3, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+                            text(0.425, text_pos-14*shift, str4, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
                             
                             n = 0;
                             
                     end
                     
                     % 6. FitVer
-                    text(0.4, text_pos-15.5*shift+n, 'FitVer: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-                    text(0.425, text_pos-15.5*shift+n, MRS_struct.info.version.fit, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
+                    text(0.4, text_pos-15.5*shift+n, 'FitVer: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+                    text(0.425, text_pos-15.5*shift+n, MRS_struct.info.version.fit, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
                     
                 end
                 

--- a/GannetLoad.m
+++ b/GannetLoad.m
@@ -21,7 +21,7 @@ end
 
 MRS_struct.info.datetime.load = datetime('now');
 MRS_struct.info.version.Gannet = '3.5.1';
-MRS_struct.info.version.load = '250912';
+MRS_struct.info.version.load = '250914';
 MRS_struct.p.bids = 0;
 VersionCheck(0, MRS_struct.info.version.Gannet);
 ToolboxCheck;
@@ -165,6 +165,12 @@ else % otherwise, run GannetPreInitialise as usual
 end
 
 CheckTargets(MRS_struct);
+
+if ~isMATLABReleaseOlderThan("R2025a") && MRS_struct.p.append
+    font_size_adj = 2.75;
+else
+    font_size_adj = 0;
+end
 
 if MRS_struct.p.PRIAM
     vox = MRS_struct.p.vox;
@@ -638,21 +644,22 @@ for ii = 1:MRS_struct.p.numScans % Loop over all files in the batch (from metabf
             end
             hold off;
             if MRS_struct.p.HERMES || any(strcmp(MRS_struct.p.target, 'GSH'))
-                text(size(MRS_struct.fids.data,2) + 0.025*size(MRS_struct.fids.data,2), F0, {'Nominal','Cr freq.'}, 'FontSize', 8);
+                text(size(MRS_struct.fids.data,2) + 0.025*size(MRS_struct.fids.data,2), F0, {'Nominal','Cr freq.'}, 'FontSize', 8 - font_size_adj);
             else
-                text(size(MRS_struct.fids.data,2) + 0.025*size(MRS_struct.fids.data,2), F0, {'Nominal','water freq.'}, 'FontSize', 8);
+                text(size(MRS_struct.fids.data,2) + 0.025*size(MRS_struct.fids.data,2), F0, {'Nominal','water freq.'}, 'FontSize', 8 - font_size_adj);
             end
             set(gca,'TickDir','out','box','off','XLim',[1 size(MRS_struct.fids.data,2)], ...
-                'YLim',[min([F0-0.06 MRS_struct.spec.F0freq{ii}-0.005]) max([F0+0.06 MRS_struct.spec.F0freq{ii}+0.005])]);
+                'YLim',[min([F0-0.06 MRS_struct.spec.F0freq{ii}-0.005]) max([F0+0.06 MRS_struct.spec.F0freq{ii}+0.005])], ...
+                'FontSize', 10 - font_size_adj);
             if size(MRS_struct.fids.data,2) == 2
                 set(gca,'XTick',[1 2]);
             end
-            xlabel('average');
-            ylabel('ppm');
+            xlabel('average', 'FontSize', 11 - font_size_adj);
+            ylabel('ppm', 'FontSize', 11 - font_size_adj);
             if MRS_struct.p.HERMES || any(strcmp(MRS_struct.p.target, 'GSH'))
-                title('Cr frequency');
+                title('Cr frequency', 'FontSize', 11 - font_size_adj);
             else
-                title('Water frequency');
+                title('Water frequency', 'FontSize', 11 - font_size_adj);
             end
             
             % Bottom left
@@ -673,9 +680,9 @@ for ii = 1:MRS_struct.p.numScans % Loop over all files in the batch (from metabf
                 end
                 imagesc(plotrealign);
                 colormap('parula');
-                title({'Cr frequency','(pre- and post-alignment)'});
-                xlabel('average');
-                ylabel('ppm');
+                title({'Cr frequency','(pre- and post-alignment)'}, 'FontSize', 11 - font_size_adj);
+                xlabel('average', 'FontSize', 11 - font_size_adj);
+                ylabel('ppm', 'FontSize', 11 - font_size_adj);
                 set(gca, 'YTick', [CrFitRange * (CrFitLimHigh - 3.02) / (CrFitLimHigh - CrFitLimLow) ...
                                    CrFitRange ...
                                    CrFitRange + CrFitRange * (CrFitLimHigh - 3.02) / (CrFitLimHigh - CrFitLimLow) ...
@@ -683,13 +690,14 @@ for ii = 1:MRS_struct.p.numScans % Loop over all files in the batch (from metabf
                     'YTickLabel', [3.02 CrFitLimLow 3.02 CrFitLimLow], ...
                     'XLim', [1 size(MRS_struct.fids.data,2)], ...
                     'YLim', [1 CrFitRange * 2], ...
-                    'TickDir','out','box','off');
+                    'TickDir','out','box','off', ...
+                    'FontSize', 10 - font_size_adj);
                 if size(MRS_struct.fids.data,2) == 2
                     set(gca, 'XTick', [1 2]);
                 end
                 % Add in labels for pre/post
-                text(size(plotrealign,2)/18*17, 0.4*size(plotrealign,1), 'PRE', 'Color', [1 1 1], 'HorizontalAlignment', 'right');
-                text(size(plotrealign,2)/18*17, 0.9*size(plotrealign,1), 'POST', 'Color', [1 1 1], 'HorizontalAlignment', 'right');
+                text(size(plotrealign,2)/18*17, 0.4*size(plotrealign,1), 'PRE', 'Color', [1 1 1], 'HorizontalAlignment', 'right', 'FontSize', 10 - font_size_adj);
+                text(size(plotrealign,2)/18*17, 0.9*size(plotrealign,1), 'POST', 'Color', [1 1 1], 'HorizontalAlignment', 'right', 'FontSize', 10 - font_size_adj);
             else
                 CrFitLimLow = 2.72;
                 CrFitLimHigh = 3.12;
@@ -728,12 +736,12 @@ for ii = 1:MRS_struct.p.numScans % Loop over all files in the batch (from metabf
             else
                 shift = 0;
             end
-            text(0.315, 1, 'Filename: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13, 'HorizontalAlignment', 'right');
+            text(0.315, 1, 'Filename: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj, 'HorizontalAlignment', 'right');
             if MRS_struct.p.join
                 text(0.34, 1+shift, [fname ' (+ ' num2str(MRS_struct.p.numFilesPerScan - 1) ' more)'], 'Units', 'normalized', ...
-                    'FontName', 'Arial', 'FontSize', 13, 'Interpreter', 'none');
+                    'FontName', 'Arial', 'FontSize', 13 - font_size_adj, 'Interpreter', 'none');
             else
-                text(0.34, 1+shift, fname, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13, 'Interpreter', 'none');
+                text(0.34, 1+shift, fname, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj, 'Interpreter', 'none');
             end
             
             vendor = MRS_struct.p.vendor;
@@ -741,56 +749,56 @@ for ii = 1:MRS_struct.p.numScans % Loop over all files in the batch (from metabf
             if ~isempty(ind)
                 vendor(ind:end) = '';
             end
-            text(0.315, 0.9, 'Vendor: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13, 'HorizontalAlignment', 'right');
-            text(0.34, 0.9, vendor, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13, 'Interpreter', 'none');
+            text(0.315, 0.9, 'Vendor: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj, 'HorizontalAlignment', 'right');
+            text(0.34, 0.9, vendor, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj, 'Interpreter', 'none');
             
-            text(0.315, 0.8, 'TE/TR: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13, 'HorizontalAlignment', 'right');
+            text(0.315, 0.8, 'TE/TR: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj, 'HorizontalAlignment', 'right');
             text(0.34, 0.8, [num2str(MRS_struct.p.TE(ii)) '/' num2str(MRS_struct.p.TR(ii)) ' ms'], 'Units', 'normalized', ...
-                'FontName', 'Arial', 'FontSize', 13, 'Interpreter', 'none');
+                'FontName', 'Arial', 'FontSize', 13 - font_size_adj, 'Interpreter', 'none');
             
-            text(0.315, 0.7, 'Averages: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13, 'HorizontalAlignment', 'right');
-            text(0.34, 0.7, num2str(MRS_struct.p.Navg(ii)), 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13);
+            text(0.315, 0.7, 'Averages: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj, 'HorizontalAlignment', 'right');
+            text(0.34, 0.7, num2str(MRS_struct.p.Navg(ii)), 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj);
             
             str = [num2str(MRS_struct.p.voxdim(ii,1)) ' \times ' num2str(MRS_struct.p.voxdim(ii,2)) ' \times ' num2str(MRS_struct.p.voxdim(ii,3)) ' mm^{3}'];
-            text(0.315, 0.6, 'Volume: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13, 'HorizontalAlignment', 'right');
-            text(0.34, 0.6, str, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13);
+            text(0.315, 0.6, 'Volume: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj, 'HorizontalAlignment', 'right');
+            text(0.34, 0.6, str, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj);
             
-            text(0.315, 0.5, 'Spectral width: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13, 'HorizontalAlignment', 'right');
-            text(0.34, 0.5, [num2str(MRS_struct.p.sw(ii)) ' Hz'], 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13, 'Interpreter', 'none');
+            text(0.315, 0.5, 'Spectral width: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj, 'HorizontalAlignment', 'right');
+            text(0.34, 0.5, [num2str(MRS_struct.p.sw(ii)) ' Hz'], 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj, 'Interpreter', 'none');
             
-            text(0.315, 0.4, 'Data points: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13, 'HorizontalAlignment', 'right');
+            text(0.315, 0.4, 'Data points: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj, 'HorizontalAlignment', 'right');
             text(0.34, 0.4, [num2str(MRS_struct.p.npoints(ii)) ' (zero-filled to ' num2str(MRS_struct.p.ZeroFillTo(ii)) ')'], ...
-                'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13, 'Interpreter', 'none');
+                'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj, 'Interpreter', 'none');
                         
-            text(0.315, 0.3, 'Alignment: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13, 'HorizontalAlignment', 'right');
+            text(0.315, 0.3, 'Alignment: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj, 'HorizontalAlignment', 'right');
             if strcmp(MRS_struct.p.alignment, 'RobustSpecReg') && MRS_struct.p.use_prealign_ref
-                text(0.34, 0.3, [MRS_struct.p.alignment ' (PreAlignRef)'], 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13);
+                text(0.34, 0.3, [MRS_struct.p.alignment ' (PreAlignRef)'], 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj);
             elseif strcmp(MRS_struct.p.alignment, 'H2O')
-                text(0.34, 0.3, 'H_{2}O', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13);
+                text(0.34, 0.3, 'H_{2}O', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj);
             else
-                text(0.34, 0.3, MRS_struct.p.alignment, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13);
+                text(0.34, 0.3, MRS_struct.p.alignment, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj);
             end
             
             str = [num2str(MRS_struct.p.LB) ' Hz'];
-            text(0.315, 0.2, 'Line-broadening: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13, 'HorizontalAlignment', 'right');
-            text(0.34, 0.2, str, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13);
+            text(0.315, 0.2, 'Line-broadening: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj, 'HorizontalAlignment', 'right');
+            text(0.34, 0.2, str, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj);
 
-            text(0.315, 0.1, 'Averaging method: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13, 'HorizontalAlignment', 'right');
+            text(0.315, 0.1, 'Averaging method: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj, 'HorizontalAlignment', 'right');
             if MRS_struct.p.weighted_averaging
-                text(0.34, 0.1, ['Weighted (' MRS_struct.p.weighted_averaging_method ')'] , 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13);
+                text(0.34, 0.1, ['Weighted (' MRS_struct.p.weighted_averaging_method ')'] , 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj);
             else
-                text(0.34, 0.1, 'Arithmetic', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13);
+                text(0.34, 0.1, 'Arithmetic', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj);
             end
 
-            text(0.315, 0, 'Rejects: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13, 'HorizontalAlignment', 'right');
+            text(0.315, 0, 'Rejects: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj, 'HorizontalAlignment', 'right');
             if MRS_struct.p.weighted_averaging
-                text(0.34, 0, 'n/a - wgt. avg. used', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13);
+                text(0.34, 0, 'n/a - wgt. avg. used', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj);
             else
-                text(0.34, 0, num2str(sum(MRS_struct.out.reject{ii})), 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13);
+                text(0.34, 0, num2str(sum(MRS_struct.out.reject{ii})), 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj);
             end
 
-            text(0.315, -0.1, 'LoadVer: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13, 'HorizontalAlignment', 'right');
-            text(0.34, -0.1, MRS_struct.info.version.load, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13);
+            text(0.315, -0.1, 'LoadVer: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj, 'HorizontalAlignment', 'right');
+            text(0.34, -0.1, MRS_struct.info.version.load, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 13 - font_size_adj);
             
             % Save output as PDF
             run_count = SavePDF(h, MRS_struct, ii, 1, kk, vox, mfilename, run_count);

--- a/GannetQuantify.m
+++ b/GannetQuantify.m
@@ -12,7 +12,15 @@ if ~isstruct(MRS_struct)
 end
 
 MRS_struct.info.datetime.quantify = datetime('now');
-MRS_struct.info.version.quantify = '250912';
+MRS_struct.info.version.quantify = '250914';
+
+if ~isMATLABReleaseOlderThan("R2025a") && MRS_struct.p.append
+    font_size_adj  = 2.75;
+    font_size_adj2 = 3.75;
+else
+    font_size_adj  = 0;
+    font_size_adj2 = 0;
+end
 
 if MRS_struct.p.PRIAM
     vox = MRS_struct.p.vox;
@@ -287,7 +295,7 @@ for kk = 1:length(vox)
         if length(T1image) > 30
             T1image = [T1image(1:12) '...' T1image(end-11:end)];
         end
-        title(sprintf(['Voxel from ' fname ' on ' T1image]), 'Interpreter', 'none');
+        title(sprintf(['Voxel from ' fname ' on ' T1image]), 'Interpreter', 'none', 'FontSize', 11 - font_size_adj2);
 
         % Post-alignment spectra + model fits
         subplot(2,2,3);
@@ -318,11 +326,12 @@ for kk = 1:length(vox)
         if length(fname) > 30
             fname = [fname(1:12) '...' fname(end-11:end)];
         end
-        text(0.4, text_pos-0.1, str, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
+        text(0.4, text_pos - 0.1, str, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
         if MRS_struct.p.join
-            text(0.425, text_pos-0.1, [fname ' (+ ' num2str(MRS_struct.p.numFilesPerScan - 1) ' more)'], 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'Interpreter', 'none');
+            text(0.425, text_pos - 0.1, [fname ' (+ ' num2str(MRS_struct.p.numFilesPerScan - 1) ' more)'], 'Units', 'normalized', ...
+                'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'Interpreter', 'none');
         else
-            text(0.425, text_pos-0.1, fname, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'Interpreter', 'none');
+            text(0.425, text_pos - 0.1, fname, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'Interpreter', 'none');
         end
 
         str = 'Anatomical image: ';
@@ -331,8 +340,8 @@ for kk = 1:length(vox)
         if length(T1image) > 30
             T1image = [T1image(1:12) '...' T1image(end-11:end)];
         end
-        text(0.4, text_pos-0.2, str, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-        text(0.425, text_pos-0.2, T1image, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'Interpreter', 'none');
+        text(0.4, text_pos - 0.2, str, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+        text(0.425, text_pos - 0.2, T1image, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'Interpreter', 'none');
 
         for jj = 1:length(target)
 
@@ -352,19 +361,19 @@ for kk = 1:length(vox)
                 if ll == 1
                     str1 = 'Relaxation-, tissue-corrected (Gasparovic et al. method)';
                     str2 = sprintf('%.2f i.u.', MRS_struct.out.(vox{kk}).(target{jj}).ConcIU_TissCorr(ii));
-                    text(0, text_pos, str1, 'Units', 'normalized', 'FontName', 'Arial', 'FontWeight', 'bold', 'FontSize', 10);
+                    text(0, text_pos, str1, 'Units', 'normalized', 'FontName', 'Arial', 'FontWeight', 'bold', 'FontSize', 10 - font_size_adj);
                 elseif ll == 2
                     text_pos = text_pos - 0.2 - shift;
                     str1 = 'Relaxation-, tissue-, alpha-corrected (Harris et al. method)';
                     str2 = sprintf('%.2f i.u.', MRS_struct.out.(vox{kk}).(target{jj}).ConcIU_AlphaTissCorr(ii));
-                    text(0, text_pos, str1, 'Units', 'normalized', 'FontName', 'Arial', 'FontWeight', 'bold', 'FontSize', 10);
+                    text(0, text_pos, str1, 'Units', 'normalized', 'FontName', 'Arial', 'FontWeight', 'bold', 'FontSize', 10 - font_size_adj);
                 elseif ll == 3
                     text_pos = text_pos - 0.4 - shift;
                     str1a = 'Relaxation-, tissue-, alpha-corrected; group-average-normalized';
                     str1b = '(Harris et al. method)';
                     str2 = sprintf('%.2f i.u.', MRS_struct.out.(vox{kk}).(target{jj}).ConcIU_AlphaTissCorr_GrpNorm(ii));
-                    text(0, text_pos, str1a, 'Units', 'normalized', 'FontName', 'Arial', 'FontWeight', 'bold', 'FontSize', 10);
-                    text(0, text_pos - 0.1, str1b, 'Units', 'normalized', 'FontName', 'Arial', 'FontWeight', 'bold', 'FontSize', 10);
+                    text(0, text_pos, str1a, 'Units', 'normalized', 'FontName', 'Arial', 'FontWeight', 'bold', 'FontSize', 10 - font_size_adj);
+                    text(0, text_pos - 0.1, str1b, 'Units', 'normalized', 'FontName', 'Arial', 'FontWeight', 'bold', 'FontSize', 10 - font_size_adj);
                 end
                 if ll == 3
                     text_pos = text_pos - 0.1*(jj+1);
@@ -372,12 +381,12 @@ for kk = 1:length(vox)
                     text_pos = text_pos - 0.1*jj;
                 end
                 if ll == 1
-                    text(0.4, text_pos, [str_target '/Water: '], 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
+                    text(0.4, text_pos, [str_target '/Water: '], 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
                 else
                     text(0.4, text_pos, [str_target '/Water (\alpha = ' num2str(MRS_struct.out.(vox{kk}).(target{jj}).alpha) '): '], ...
-                        'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
+                        'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
                 end
-                text(0.425, text_pos, str2, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
+                text(0.425, text_pos, str2, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
 
                 if MRS_struct.p.HERMES
                     shift = shift + 0.1*(numel(target)-1);
@@ -389,8 +398,8 @@ for kk = 1:length(vox)
 
         end
 
-        text(0.4, text_pos - 0.15, 'QuantifyVer: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10, 'HorizontalAlignment', 'right');
-        text(0.425, text_pos - 0.15, MRS_struct.info.version.quantify, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10);
+        text(0.4, text_pos - 0.15, 'QuantifyVer: ', 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj, 'HorizontalAlignment', 'right');
+        text(0.425, text_pos - 0.15, MRS_struct.info.version.quantify, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 10 - font_size_adj);
 
         % Save output as PDF
         run_count = SavePDF(h, MRS_struct, ii, 1, kk, vox, mfilename, run_count);

--- a/GannetSegment.m
+++ b/GannetSegment.m
@@ -486,10 +486,10 @@ if MRS_struct.p.hide && exist('figTitle','var')
 end
 
 
-function img_montage = PlotSegmentedVoxels(struc, voxoff, voxmaskvol, GM_vox, WM_vox, CSF_vox, font_size_adj)
+function img_montage = PlotSegmentedVoxels(struc, voxoff, vox_mask_vol, GM_vox, WM_vox, CSF_vox, font_size_adj)
 
 img_t      = flipud(voxel2world_space(spm_vol(struc), voxoff));
-mask_t     = flipud(voxel2world_space(voxmaskvol, voxoff));
+mask_t     = flipud(voxel2world_space(vox_mask_vol, voxoff));
 mask_t_GM  = flipud(voxel2world_space(GM_vox, voxoff));
 mask_t_WM  = flipud(voxel2world_space(WM_vox, voxoff));
 mask_t_CSF = flipud(voxel2world_space(CSF_vox, voxoff));

--- a/GannetSegment.m
+++ b/GannetSegment.m
@@ -17,7 +17,13 @@ if ~isstruct(MRS_struct)
 end
 
 MRS_struct.info.datetime.segment = datetime('now');
-MRS_struct.info.version.segment = '250912';
+MRS_struct.info.version.segment = '250914';
+
+if ~isMATLABReleaseOlderThan("R2025a") && MRS_struct.p.append
+    font_size_adj = 2.75;
+else
+    font_size_adj = 0;
+end
 
 warning('off'); % temporarily suppress warning messages
 
@@ -360,16 +366,20 @@ for kk = 1:length(vox)
         if length(fname) > 30
             fname = [fname(1:12) '...' fname(end-11:end)];
         end
-        text(0.5, text_pos-0.12, 'Filename: ', 'Units', 'normalized', 'FontName', 'Arial', 'HorizontalAlignment','right', 'VerticalAlignment', 'top', 'FontSize', 13);
-        text(0.5, text_pos-0.12, [' ' fname], 'Units', 'normalized', 'FontName', 'Arial', 'VerticalAlignment', 'top', 'FontSize', 13, 'Interpreter', 'none');
+        text(0.5, text_pos-0.12, 'Filename: ', 'Units', 'normalized', 'FontName', 'Arial', ...
+            'HorizontalAlignment','right', 'VerticalAlignment', 'top', 'FontSize', 13 - font_size_adj);
+        text(0.5, text_pos-0.12, [' ' fname], 'Units', 'normalized', 'FontName', 'Arial', ...
+            'VerticalAlignment', 'top', 'FontSize', 13 - font_size_adj, 'Interpreter', 'none');
         
         [~,name,ext] = fileparts(MRS_struct.mask.(vox{kk}).T1image{ii});
         T1image = [name ext];
         if length(T1image) > 30
             T1image = [T1image(1:12) '...' T1image(end-11:end)];
         end
-        text(0.5, text_pos-0.24, 'Anatomical image: ', 'Units', 'normalized', 'FontName', 'Arial', 'HorizontalAlignment','right', 'VerticalAlignment', 'top', 'FontSize', 13);
-        text(0.5, text_pos-0.24, [' ' T1image], 'Units', 'normalized', 'FontName', 'Arial', 'VerticalAlignment', 'top', 'FontSize', 13, 'Interpreter', 'none');
+        text(0.5, text_pos-0.24, 'Anatomical image: ', 'Units', 'normalized', 'FontName', 'Arial', ...
+            'HorizontalAlignment','right', 'VerticalAlignment', 'top', 'FontSize', 13 - font_size_adj);
+        text(0.5, text_pos-0.24, [' ' T1image], 'Units', 'normalized', 'FontName', 'Arial', ...
+            'VerticalAlignment', 'top', 'FontSize', 13 - font_size_adj, 'Interpreter', 'none');
         
         % Print correction of institutional units only feasible if water-scaling is performed, skip otherwise
         text_pos = text_pos-0.24;
@@ -396,25 +406,30 @@ for kk = 1:length(vox)
                         str1 = [target{jj} '/Water (CSF-corrected): '];
                         str2 = sprintf(' %.2f i.u.', MRS_struct.out.(vox{kk}).(target{jj}).ConcIU_CSFcorr(ii));
                 end
-                text(0.5, text_pos, str1, 'Units', 'normalized', 'FontName', 'Arial', 'HorizontalAlignment','right', 'VerticalAlignment', 'top', 'FontSize', 13);
-                text(0.5, text_pos, str2, 'Units', 'normalized', 'FontName', 'Arial', 'VerticalAlignment', 'top', 'FontSize', 13);
+                text(0.5, text_pos, str1, 'Units', 'normalized', 'FontName', 'Arial', 'HorizontalAlignment','right', 'VerticalAlignment', 'top', 'FontSize', 13 - font_size_adj);
+                text(0.5, text_pos, str2, 'Units', 'normalized', 'FontName', 'Arial', 'VerticalAlignment', 'top', 'FontSize', 13 - font_size_adj);
             end
         end
         
         str = sprintf(' %.2f', MRS_struct.out.(vox{kk}).tissue.fGM(ii));
-        text(0.5, text_pos-0.12, 'GM voxel fraction: ', 'Units', 'normalized', 'FontName', 'Arial', 'HorizontalAlignment','right', 'VerticalAlignment', 'top', 'FontSize', 13);
-        text(0.5, text_pos-0.12, str, 'Units', 'normalized', 'FontName', 'Arial', 'VerticalAlignment', 'top', 'FontSize', 13);
+        text(0.5, text_pos-0.12, 'GM voxel fraction: ', 'Units', 'normalized', 'FontName', 'Arial', ...
+            'HorizontalAlignment','right', 'VerticalAlignment', 'top', 'FontSize', 13 - font_size_adj);
+        text(0.5, text_pos-0.12, str, 'Units', 'normalized', 'FontName', 'Arial', 'VerticalAlignment', 'top', 'FontSize', 13 - font_size_adj);
         
         str = sprintf(' %.2f', MRS_struct.out.(vox{kk}).tissue.fWM(ii));
-        text(0.5, text_pos-0.24, 'WM voxel fraction: ', 'Units', 'normalized', 'FontName', 'Arial', 'HorizontalAlignment','right', 'VerticalAlignment', 'top', 'FontSize', 13);
-        text(0.5, text_pos-0.24, str, 'Units', 'normalized', 'FontName', 'Arial', 'VerticalAlignment', 'top', 'FontSize', 13);
+        text(0.5, text_pos-0.24, 'WM voxel fraction: ', 'Units', 'normalized', 'FontName', 'Arial', ...
+            'HorizontalAlignment','right', 'VerticalAlignment', 'top', 'FontSize', 13 - font_size_adj);
+        text(0.5, text_pos-0.24, str, 'Units', 'normalized', 'FontName', 'Arial', 'VerticalAlignment', 'top', 'FontSize', 13 - font_size_adj);
         
         str = sprintf(' %.2f', MRS_struct.out.(vox{kk}).tissue.fCSF(ii));
-        text(0.5, text_pos-0.36, 'CSF voxel fraction: ', 'Units', 'normalized', 'FontName', 'Arial', 'HorizontalAlignment','right', 'VerticalAlignment', 'top', 'FontSize', 13);
-        text(0.5, text_pos-0.36, str, 'Units', 'normalized', 'FontName', 'Arial', 'VerticalAlignment', 'top', 'FontSize', 13);
+        text(0.5, text_pos-0.36, 'CSF voxel fraction: ', 'Units', 'normalized', 'FontName', 'Arial', ...
+            'HorizontalAlignment','right', 'VerticalAlignment', 'top', 'FontSize', 13 - font_size_adj);
+        text(0.5, text_pos-0.36, str, 'Units', 'normalized', 'FontName', 'Arial', 'VerticalAlignment', 'top', 'FontSize', 13 - font_size_adj);
         
-        text(0.5, text_pos-0.48, 'SegmentVer: ', 'Units', 'normalized', 'FontName', 'Arial', 'HorizontalAlignment','right', 'VerticalAlignment', 'top', 'FontSize', 13);
-        text(0.5, text_pos-0.48, [' ' MRS_struct.info.version.segment], 'Units', 'normalized', 'FontName', 'Arial', 'VerticalAlignment', 'top', 'FontSize', 13);
+        text(0.5, text_pos-0.48, 'SegmentVer: ', 'Units', 'normalized', 'FontName', 'Arial', ...
+            'HorizontalAlignment','right', 'VerticalAlignment', 'top', 'FontSize', 13 - font_size_adj);
+        text(0.5, text_pos-0.48, [' ' MRS_struct.info.version.segment], 'Units', 'normalized', 'FontName', 'Arial', ...
+            'VerticalAlignment', 'top', 'FontSize', 13 - font_size_adj);
         
         % Voxel segmentation
         if isfield(MRS_struct.p,'TablePosition')
@@ -424,7 +439,7 @@ for kk = 1:length(vox)
         end
         
         % Plot segmented voxel as a montage
-        MRS_struct.mask.(vox{kk}).img_montage{ii} = PlotSegmentedVoxels(struc, voxoff, vox_mask_vol, GM_vox, WM_vox, CSF_vox);
+        MRS_struct.mask.(vox{kk}).img_montage{ii} = PlotSegmentedVoxels(struc, voxoff, vox_mask_vol, GM_vox, WM_vox, CSF_vox, font_size_adj);
 
         if strcmp(MRS_struct.p.vendor, 'Siemens_rda')
             [~,name,ext] = fileparts(MRS_struct.metabfile{1,ii*2-1});
@@ -440,8 +455,7 @@ for kk = 1:length(vox)
         if length(T1image) > 30
             T1image = [T1image(1:12) '...' T1image(end-11:end)];
         end
-        t = ['Voxel from ' fname ' on ' T1image];
-        title(t, 'FontName', 'Arial', 'FontSize', 15, 'Interpreter', 'none');
+        title(['Voxel from ' fname ' on ' T1image], 'FontName', 'Arial', 'FontSize', 15 - font_size_adj, 'Interpreter', 'none');
         
         % Save output as PDF
         run_count = SavePDF(h, MRS_struct, ii, 1, kk, vox, mfilename, run_count);
@@ -472,7 +486,7 @@ if MRS_struct.p.hide && exist('figTitle','var')
 end
 
 
-function img_montage = PlotSegmentedVoxels(struc, voxoff, voxmaskvol, GM_vox, WM_vox, CSF_vox)
+function img_montage = PlotSegmentedVoxels(struc, voxoff, voxmaskvol, GM_vox, WM_vox, CSF_vox, font_size_adj)
 
 img_t      = flipud(voxel2world_space(spm_vol(struc), voxoff));
 mask_t     = flipud(voxel2world_space(voxmaskvol, voxoff));
@@ -542,11 +556,8 @@ img_montage = cat(2, img_t, img_t_GM, img_t_WM, img_t_CSF);
 hb = subplot(2,3,1:3);
 imagesc(img_montage);
 axis equal tight off;
-text(floor(size(mask_t,2)/2), 20, 'Voxel', 'Color', [1 1 1], 'FontSize', 20, 'HorizontalAlignment', 'center');
-text(floor(size(mask_t,2)) + floor(size(mask_t,2)/2), 20, 'GM', 'Color', [1 1 1], 'FontSize', 20, 'HorizontalAlignment', 'center');
-text(2*floor(size(mask_t,2)) + floor(size(mask_t,2)/2), 20, 'WM', 'Color', [1 1 1], 'FontSize', 20, 'HorizontalAlignment', 'center');
-text(3*floor(size(mask_t,2)) + floor(size(mask_t,2)/2), 20, 'CSF', 'Color', [1 1 1], 'FontSize', 20, 'HorizontalAlignment', 'center');
+text(floor(size(mask_t,2)/2), 20, 'Voxel', 'Color', [1 1 1], 'FontSize', 20 - font_size_adj, 'HorizontalAlignment', 'center');
+text(floor(size(mask_t,2)) + floor(size(mask_t,2)/2), 20, 'GM', 'Color', [1 1 1], 'FontSize', 20 - font_size_adj, 'HorizontalAlignment', 'center');
+text(2*floor(size(mask_t,2)) + floor(size(mask_t,2)/2), 20, 'WM', 'Color', [1 1 1], 'FontSize', 20 - font_size_adj, 'HorizontalAlignment', 'center');
+text(3*floor(size(mask_t,2)) + floor(size(mask_t,2)/2), 20, 'CSF', 'Color', [1 1 1], 'FontSize', 20 - font_size_adj, 'HorizontalAlignment', 'center');
 set(hb, 'Position', [0 0.17 1 1]);
-
-
-

--- a/PlotPrePostAlign.m
+++ b/PlotPrePostAlign.m
@@ -1,6 +1,12 @@
 function PlotPrePostAlign(MRS_struct, vox, ii, kk)
 % Plot pre-/post-alignment spectra
-% Updates by MGSaleh 2016, MM 2017-2024
+% Updates by MGSaleh 2016, MM 2017-2025
+
+if ~isMATLABReleaseOlderThan("R2025a") && MRS_struct.p.append
+    font_size_adj = 2.75;
+else
+    font_size_adj = 0;
+end
 
 if MRS_struct.p.HERMES
 
@@ -186,26 +192,26 @@ end
 
 if ~strcmp(MRS_struct.p.alignment, 'none')
     if strcmp(MRS_struct.p.target{1}, 'EtOH')
-        legend({'pre', 'post'}, 'EdgeColor', [1 1 1], 'Location', 'northwest');
+        legend({'pre', 'post'}, 'EdgeColor', [1 1 1], 'Location', 'northwest', 'FontSize', 9 - font_size_adj);
     else
-        legend({'pre', 'post'}, 'EdgeColor', [1 1 1]);
+        legend({'pre', 'post'}, 'EdgeColor', [1 1 1], 'FontSize', 9 - font_size_adj);
     end
 end
 axis([0 5 yAxisMin yAxisMax]);
-set(gca,'XDir', 'reverse', 'TickDir', 'out', 'box', 'off', 'XTick', 0:5);
+set(gca, 'XDir', 'reverse', 'TickDir', 'out', 'box', 'off', 'XTick', 0:5, 'FontSize', 10 - font_size_adj);
 set(get(gca, 'YAxis'), 'Visible', 'off');
-xlabel('ppm');
+xlabel('ppm', 'FontSize', 11 - font_size_adj);
 if ~strcmp(MRS_struct.p.alignment, 'none')
     if MRS_struct.p.HERMES
-        title({'Difference spectra'; '(pre- and post-alignment)'});
+        title({'Difference spectra'; '(pre- and post-alignment)'}, 'FontSize', 11 - font_size_adj);
     else
-        title({'Difference spectrum'; '(pre- and post-alignment)'});
+        title({'Difference spectrum'; '(pre- and post-alignment)'}, 'FontSize', 11 - font_size_adj);
     end
 else
     if MRS_struct.p.HERMES
-        title({'Difference spectra'; '(no alignment)'});
+        title({'Difference spectra'; '(no alignment)'}, 'FontSize', 11 - font_size_adj);
     else
-        title({'Difference spectrum'; '(no alignment)'});
+        title({'Difference spectrum'; '(no alignment)'}, 'FontSize', 11 - font_size_adj);
     end
 end
 

--- a/PlotPrePostAlign2.m
+++ b/PlotPrePostAlign2.m
@@ -1,6 +1,12 @@
 function PlotPrePostAlign2(MRS_struct, vox, ii)
 % Plot pre-/post-alignment spectra
-% Updates by MGSaleh 2016, MM 2017-2020
+% Updates by MGSaleh 2016, MM 2017-2025
+
+if ~isMATLABReleaseOlderThan("R2025a") && MRS_struct.p.append
+    font_size_adj = 2.75;
+else
+    font_size_adj = 0;
+end
 
 for kk = 1:length(vox)
     
@@ -144,13 +150,13 @@ for kk = 1:length(vox)
     end
     
     axis([0 5 yAxisMin yAxisMax]);
-    set(gca,'XDir','reverse','TickDir','out','box','off','XTick',0:5);
-    set(get(gca,'YAxis'),'Visible','off');
+    set(gca, 'XDir', 'reverse', 'TickDir', 'out', 'box', 'off', 'XTick', 0:5, 'FontSize', 10 - font_size_adj);
+    set(get(gca,'YAxis'), 'Visible', 'off');
     xlabel('ppm');
     if MRS_struct.p.HERMES
-        title('Difference spectra and model fits');
+        title('Difference spectra and model fits', 'FontSize', 11 - font_size_adj);
     else
-        title('Difference spectrum and model fit');
+        title('Difference spectrum and model fit', 'FontSize', 11 - font_size_adj);
     end
     
 end

--- a/SavePDF.m
+++ b/SavePDF.m
@@ -1,5 +1,11 @@
 function run_count = SavePDF(h, MRS_struct, ii, jj, kk, vox, module, run_count, target)
 
+if ~isMATLABReleaseOlderThan("R2025a") && MRS_struct.p.append
+    font_size_adj = 2.75;
+else
+    font_size_adj = 0;
+end
+
 % Gannet logo
 axes('Position', [0.8825, 0.04, 0.125, 0.125], 'Units', 'normalized');
 Gannet_logo = fullfile(fileparts(which('GannetLoad')), 'Gannet3_logo.png');
@@ -13,13 +19,13 @@ d.bottom = 0.02;
 d.width  = 1;
 d.height = 0.02;
 axes('Position', [d.left d.bottom d.width d.height], 'Units', 'normalized');
-text(0.9925, 0, MRS_struct.info.version.Gannet, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 14, 'FontWeight', 'bold', 'HorizontalAlignment', 'right');
+text(0.9925, 0, MRS_struct.info.version.Gannet, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 14 - font_size_adj, 'FontWeight', 'bold', 'HorizontalAlignment', 'right');
 axis off;
 
 % Gannet documentation
 axes('Position', [d.left d.bottom d.width d.height], 'Units', 'normalized');
 str = 'For complete documentation, please visit: https://markmikkelsen.github.io/Gannet-docs';
-text(0.5, 0, str, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 11, 'HorizontalAlignment', 'center');
+text(0.5, 0, str, 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 11 - font_size_adj, 'HorizontalAlignment', 'center');
 axis off square;
 
 % Batch number and output time
@@ -29,11 +35,11 @@ if strcmp(module,'GannetFit') && MRS_struct.p.HERMES && MRS_struct.p.append && ~
     if strcmp(target,'GABAGlx')
         target = 'GABA+Glx';
     end
-    text(0.0075, 0, ['Batch file: ' num2str(ii) ' of ' num2str(MRS_struct.p.numScans) ' (' target ')'], 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 11, 'HorizontalAlignment', 'left');
+    text(0.0075, 0, ['Batch file: ' num2str(ii) ' of ' num2str(MRS_struct.p.numScans) ' (' target ')'], 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 11 - font_size_adj, 'HorizontalAlignment', 'left');
 else
-    text(0.0075, 0, ['Batch file: ' num2str(ii) ' of ' num2str(MRS_struct.p.numScans)], 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 11, 'HorizontalAlignment', 'left');
+    text(0.0075, 0, ['Batch file: ' num2str(ii) ' of ' num2str(MRS_struct.p.numScans)], 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 11 - font_size_adj, 'HorizontalAlignment', 'left');
 end
-text(0.9925, 0, char(datetime('now','Format','dd-MMM-y HH:mm:ss')), 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 11, 'HorizontalAlignment', 'right');
+text(0.9925, 0, char(datetime('now','Format','dd-MMM-y HH:mm:ss')), 'Units', 'normalized', 'FontName', 'Arial', 'FontSize', 11 - font_size_adj, 'HorizontalAlignment', 'right');
 axis off;
 
 if any(strcmp(listfonts, 'Arial'))


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the segmentation and fitting routines, focusing on more robust image quality metrics, improved reproducibility, and better compatibility with future MATLAB releases. The main changes include an overhaul of the segmentation quality metric calculations, code modernization and variable renaming for clarity, and dynamic font size adjustment for figures to ensure consistent appearance across MATLAB versions.

**Segmentation and Quality Metrics Improvements:**

* Overhauled the calculation of MRI segmentation quality metrics in `Seg.m` to use more robust statistics (median and MAD instead of mean and standard deviation), added additional metrics (FBER, WM2MAX, SNR variants), and generalized the threshold for partial volume effects with a new `prob_threshold` parameter. These changes improve the reliability and interpretability of tissue probability maps and quality metrics. [[1]](diffhunk://#diff-28540e4c681f82c80c828113cc36637c0580cb34fa744730176217ab432abdd8R43-R44) [[2]](diffhunk://#diff-28540e4c681f82c80c828113cc36637c0580cb34fa744730176217ab432abdd8L91-R205)

* Refactored variable names throughout `Seg.m` for clarity (e.g., `air`→`BG`, `GMvol`→`GM_vol`) and updated downstream calculations and function signatures accordingly, including the plotting function `PlotSegmentedVoxels`. [[1]](diffhunk://#diff-28540e4c681f82c80c828113cc36637c0580cb34fa744730176217ab432abdd8L91-R205) [[2]](diffhunk://#diff-28540e4c681f82c80c828113cc36637c0580cb34fa744730176217ab432abdd8L250-R283) [[3]](diffhunk://#diff-28540e4c681f82c80c828113cc36637c0580cb34fa744730176217ab432abdd8L351-R390)

**MATLAB Compatibility and Figure Presentation:**

* Added dynamic font size adjustment in both `GannetCoRegister.m` and `GannetFit.m` for MATLAB R2025a and newer, ensuring consistent figure appearance regardless of MATLAB version or the `append` parameter. This includes updating all relevant `text`, `title`, and axis font size settings. [[1]](diffhunk://#diff-a766d51abecc390ca52dcb58efa7af15d8a5cfdd59d3aa43d447f128e547e47dL26-R32) [[2]](diffhunk://#diff-a766d51abecc390ca52dcb58efa7af15d8a5cfdd59d3aa43d447f128e547e47dL191-R224) [[3]](diffhunk://#diff-a766d51abecc390ca52dcb58efa7af15d8a5cfdd59d3aa43d447f128e547e47dL240-R253) [[4]](diffhunk://#diff-ee5d8ec31c5ee7c2420d2863758c55bba5038d59f6b588a9d53b8f1a392b8b97L15-R23) [[5]](diffhunk://#diff-ee5d8ec31c5ee7c2420d2863758c55bba5038d59f6b588a9d53b8f1a392b8b97L620-R628) [[6]](diffhunk://#diff-ee5d8ec31c5ee7c2420d2863758c55bba5038d59f6b588a9d53b8f1a392b8b97L638-R646) [[7]](diffhunk://#diff-ee5d8ec31c5ee7c2420d2863758c55bba5038d59f6b588a9d53b8f1a392b8b97L648-R662) [[8]](diffhunk://#diff-ee5d8ec31c5ee7c2420d2863758c55bba5038d59f6b588a9d53b8f1a392b8b97L672-R680)

**Versioning:**

* Updated version strings in `GannetCoRegister.m` and `GannetFit.m` to reflect the new release (`250914`). [[1]](diffhunk://#diff-a766d51abecc390ca52dcb58efa7af15d8a5cfdd59d3aa43d447f128e547e47dL26-R32) [[2]](diffhunk://#diff-ee5d8ec31c5ee7c2420d2863758c55bba5038d59f6b588a9d53b8f1a392b8b97L15-R23)