### PR TITLE
Use uint32 for header read; bump load version

### DIFF
--- a/GERead.m
+++ b/GERead.m
@@ -217,7 +217,7 @@ hdr_value = fread(fid, rdb_hdr_dab_stop_rcv, 'integer*2');
 fseek(fid, 0, 'bof');
 f_hdr_value = fread(fid, rdb_hdr_user19, 'real*4');
 fseek(fid, 0, 'bof');
-i_hdr_value = fread(fid, max(rdb_hdr_off_image, rdb_hdr_ps_mps_freq), 'integer*4');
+i_hdr_value = fread(fid, max(rdb_hdr_off_image, rdb_hdr_ps_mps_freq), 'uint32');
 
 if rdbm_rev_num > 11.0
     pfile_header_size = i_hdr_value(rdb_hdr_off_data);

--- a/GannetLoad.m
+++ b/GannetLoad.m
@@ -21,7 +21,7 @@ end
 
 MRS_struct.info.datetime.load = datetime('now');
 MRS_struct.info.version.Gannet = '3.5.3';
-MRS_struct.info.version.load = '260312';
+MRS_struct.info.version.load = '260618';
 MRS_struct.p.bids = 0;
 VersionCheck(0, MRS_struct.info.version.Gannet);
 ToolboxCheck;


### PR DESCRIPTION
GERead.m: change fread type for i_hdr_value from 'integer*4' to 'uint32' to correctly interpret header fields (e.g. offsets/frequencies) as unsigned 32-bit values. This ensures header values are read with the correct signedness.