### PR TITLE
Add bounds to FitChoCr

### DIFF
--- a/FitChoCr.m
+++ b/FitChoCr.m
@@ -2,28 +2,31 @@ function [FitParams, rejectframe, residCr] = FitChoCr(freq, FrameData, initx, La
 
 warning('off','stats:nlinfit:IterationLimitExceeded'); % temporarily suppress warning messages about iteration limit
 
-% All parameters in initx are in standard units.
-% Conversion factors to FWHM in Hz, delta f0 in Hz, phase in degrees
-conv = [1 2*LarmorFreq LarmorFreq 180/pi 1 1 1];
-initx = initx./conv;
+% All parameters in initx are in standard units
+% Convert FWHM, delta f0 to ppm
+conv = [2*LarmorFreq LarmorFreq];
+initx(2:3) = initx(2:3) ./ conv;
 
 lsqopts = optimset('lsqcurvefit');
 lsqopts = optimset(lsqopts,'MaxIter',800,'TolX',1e-4,'TolFun',1e-4,'Display','off');
 nlinopts = statset('nlinfit');
 nlinopts = statset(nlinopts,'MaxIter',400,'TolX',1e-6,'TolFun',1e-6);
 
+lb = [0 0 initx(3)-0.02 -pi -Inf -Inf 0];
+ub = [2*initx(1) 2*initx(2) initx(3)+0.02 pi Inf Inf 3];
+
 nframes = size(FrameData,2);
 FitParams = zeros(nframes,7);
 
 for ii = 1:nframes
-    initx = lsqcurvefit(@TwoLorentzModel, initx, freq', real(FrameData(:,ii)), [], [], lsqopts);
+    initx = lsqcurvefit(@TwoLorentzModel, initx, freq', real(FrameData(:,ii)), lb, ub, lsqopts);
     [FitParams(ii,:), residCr] = nlinfit(freq', real(FrameData(:,ii)), @TwoLorentzModel, initx, nlinopts);
     
-    %fit_plot = TwoLorentzModel(FitParams(ii,:), freq);
-    %figure(3);
-    %plot(freq', real(FrameData(:,ii)), 'g', freq', fit_plot,'b');
-    %set(gca,'XDir','reverse');
-    %drawnow;
+    % fit_plot = TwoLorentzModel(FitParams(ii,:), freq);
+    % figure(3);
+    % plot(freq', real(FrameData(:,ii)), 'g', freq', fit_plot, 'b');
+    % set(gca,'XDir','reverse');
+    % drawnow;
 end
 
 for ii = 1:size(FitParams,1)

--- a/GannetFit.m
+++ b/GannetFit.m
@@ -12,7 +12,7 @@ if ~isstruct(MRS_struct)
 end
 
 MRS_struct.info.datetime.fit = datetime('now');
-MRS_struct.info.version.fit = '250914';
+MRS_struct.info.version.fit = '260618';
 
 if ~isMATLABReleaseOlderThan("R2025a") && MRS_struct.p.append
     font_size_adj  = 2.75;
@@ -950,7 +950,7 @@ for kk = 1:length(vox)
                 Baseline_offset = real(ChoCrMeanSpec(1) + ChoCrMeanSpec(end)) / 2;
                 Width_estimate  = 0.05;
                 Area_estimate   = (max(real(ChoCrMeanSpec)) - min(real(ChoCrMeanSpec))) * Width_estimate * 4;
-                ChoCr_initx     = [Area_estimate Width_estimate 3.02 0 Baseline_offset 0 1] ...
+                ChoCr_initx     = [Area_estimate Width_estimate 3.02 0 Baseline_offset 0 0.5] ...
                     .* [1 2*MRS_struct.p.LarmorFreq(ii) MRS_struct.p.LarmorFreq(ii) 180/pi 1 1 1];
                 [ChoCrModelParam, ~, residChoCr] = FitChoCr(freq(freqboundsChoCr), ChoCrMeanSpec, ChoCr_initx, MRS_struct.p.LarmorFreq(ii));
                 MRS_struct.out.(vox{kk}).ChoCr.ModelParam(ii,:) = ChoCrModelParam ./ [1 2*MRS_struct.p.LarmorFreq(ii) MRS_struct.p.LarmorFreq(ii) 180/pi 1 1 1];

--- a/TwoLorentzModel.m
+++ b/TwoLorentzModel.m
@@ -4,7 +4,7 @@ function F = TwoLorentzModel(x, freq)
 % CJE LorentzModel
 % Lorentzian  = (1/pi) * (hwhm) / (deltaf^2 + hwhm^2) (Wolfram)
 % Peak height of Lorentzian = 4 / (pi*hwhm)
-% This defnition of the Lorentzian has Area = 1
+% This definition of the Lorentzian has Area = 1
 
 area      = x(1);
 hwhm      = x(2);


### PR DESCRIPTION
Added explicit lower (`lb`) and upper (`ub`) bounds to the `lsqcurvefit` function in `FitChoCr.m` to constrain parameter optimization and improve fit stability